### PR TITLE
[feat] #6 Axios 인터셉터 구현 — 토큰 자동 첨부 및 갱신

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,7 +1,7 @@
-import axios from 'axios'
+import axios, { type InternalAxiosRequestConfig } from 'axios'
 
 import { useAuthStore } from '@/stores/authStore'
-import type { ApiResponse } from '@/types/api'
+import type { ApiResponse, RefreshResponse } from '@/types/api'
 
 const apiBaseUrl = import.meta.env.VITE_API_BASE_URL
 
@@ -17,6 +17,33 @@ export const apiClient = axios.create({
   },
 })
 
+interface RetryableConfig extends InternalAxiosRequestConfig {
+  _retry?: boolean // "이 요청은 이미 한 번 재시도했다"는 표시
+}
+
+let isRefreshing = false // 현재 토큰 갱신 중인지 여부
+let failedQueue: Array<{
+  resolve: (token: string) => void
+  reject: (reason: unknown) => void
+}> = []
+
+const processQueue = (error: unknown, token: string | null = null) => {
+  failedQueue.forEach(({ resolve, reject }) => {
+    if (error) {
+      reject(error)
+    } else {
+      resolve(token!)
+    }
+  })
+  failedQueue = []
+}
+
+const retryRequest = (request: RetryableConfig, token: string) => {
+  request._retry = true
+  request.headers.set('Authorization', `Bearer ${token}`)
+  return apiClient(request)
+}
+
 apiClient.interceptors.request.use((config) => {
   const { accessToken } = useAuthStore.getState()
 
@@ -28,12 +55,59 @@ apiClient.interceptors.request.use((config) => {
 })
 
 apiClient.interceptors.response.use(
-  (response) => response,
-  (error: unknown) => {
-    if (axios.isAxiosError<ApiResponse<unknown>>(error) && error.response?.status === 401) {
-      useAuthStore.getState().clearAuth()
+  (response) => response, // 성공 응답은 그냥 통과
+  async (error: unknown) => {
+    if (!axios.isAxiosError<ApiResponse<unknown>>(error) || error.response?.status !== 401) {
+      return Promise.reject(error)
     }
 
-    return Promise.reject(error)
+    const originalRequest = error.config as RetryableConfig
+
+    // refresh/logout 자체의 401은 처리하지 않음 (데드락/무한루프 방지)
+    if (originalRequest.url === '/auth/refresh' || originalRequest.url === '/auth/logout') {
+      return Promise.reject(error)
+    }
+
+    // 재시도한 요청도 401이면 바로 로그아웃
+    if (originalRequest._retry) {
+      useAuthStore.getState().clearAuth()
+      window.location.href = '/login'
+      return Promise.reject(error)
+    }
+
+    if (isRefreshing) {
+      return new Promise<string>((resolve, reject) => {
+        failedQueue.push({ resolve, reject })
+      }).then((token) => {
+        return retryRequest(originalRequest, token)
+      })
+    }
+
+    originalRequest._retry = true
+    isRefreshing = true
+
+    try {
+      const { data } = await apiClient.post<ApiResponse<RefreshResponse>>('/auth/refresh')
+      const newToken = data.data!.accessToken
+
+      useAuthStore.getState().setAccessToken(newToken)
+      processQueue(null, newToken)
+
+      return retryRequest(originalRequest, newToken)
+    } catch (refreshError) {
+      processQueue(refreshError)
+      useAuthStore.getState().clearAuth()
+
+      try {
+        await apiClient.post('/auth/logout')
+      } catch {
+        // best-effort: 로그아웃 API 실패해도 클라이언트는 로그아웃 처리
+      }
+
+      window.location.href = '/login'
+      return Promise.reject(refreshError)
+    } finally {
+      isRefreshing = false
+    }
   }
 )

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -12,3 +12,7 @@ export interface PageResponse<T> {
   hasNext: boolean
   totalElements?: number
 }
+
+export interface RefreshResponse {
+  accessToken: string
+}


### PR DESCRIPTION
## ✅ 무엇을 변경했나요?
- `src/api/client.ts`: 응답 인터셉터에 토큰 갱신 로직 구현 (isRefreshing 플래그 + failedQueue 큐잉 패턴)
- `src/types/api.ts`: 토큰 갱신 응답 타입 `RefreshResponse` 추가

## 🎯 왜 변경했나요? (문제/배경)
- 이 PR이 해결하는 문제: 모든 API 호출에서 토큰 첨부 로직을 개별적으로 작성해야 하는 중복, Access Token 만료 시 사용자 경험 단절
- 관련 맥락/배경: Access Token은 Zustand 전역 상태로 관리하며, Refresh Token은 HttpOnly Cookie로 서버에서 자동 첨부됨

## 🔗 관련 이슈
- Closes #6

## 🧪 테스트/검증 방법
- [x] 로컬 빌드/실행 확인
- [ ] 핵심 시나리오 수동 테스트

### 검증 시나리오
1. 유효한 Access Token으로 API 요청 → Authorization 헤더 자동 첨부 확인
2. Access Token 만료(401) → `/auth/refresh` 호출 → 원래 요청 자동 재시도 확인
3. Refresh Token도 만료(refresh 401) → 로그아웃 처리 후 `/login` 리다이렉트 확인

## ✅ 체크리스트
- [x] 코드가 컴파일/빌드 됩니다
- [x] 불필요한 디버그 코드/로그를 제거했습니다
- [x] 에러 케이스를 고려했습니다
- [ ] (Front-end) UI/상태 변경이 의도대로 동작합니다

## 📝 기타 공유사항 (선택)
- 리뷰 시 참고할 점: refresh/logout 엔드포인트 자체의 401은 인터셉터에서 처리하지 않음 (데드락/무한루프 방지). 관련 백엔드 작업으로 logout public 경로 허용 이슈(#98) 별도 진행 예정