### PR TITLE
[feat] #8 공통 AppLayout 및 Header 네비게이션 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,10 +33,9 @@ export default function App() {
           <Route path="/statistics" element={<StatisticsPage />} />
           <Route path="/notifications" element={<NotificationsPage />} />
           <Route path="/profile" element={<ProfilePage />} />
+          <Route path="*" element={<NotFoundPage />} />
         </Route>
       </Route>
-
-      <Route path="*" element={<NotFoundPage />} />
     </Routes>
   )
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,11 @@ import AppLayout from '@/components/layout/AppLayout'
 import LoginPage from '@/pages/LoginPage'
 import SignupPage from '@/pages/SignupPage'
 import HomePage from '@/pages/HomePage'
+import RoutinesPage from '@/pages/RoutinesPage'
+import ChallengesPage from '@/pages/ChallengesPage'
+import FeedPage from '@/pages/FeedPage'
+import StatisticsPage from '@/pages/StatisticsPage'
+import NotificationsPage from '@/pages/NotificationsPage'
 import ProfilePage from '@/pages/ProfilePage'
 import NotFoundPage from '@/pages/NotFoundPage'
 
@@ -22,6 +27,11 @@ export default function App() {
       <Route element={<ProtectedRoute />}>
         <Route element={<AppLayout />}>
           <Route path="/" element={<HomePage />} />
+          <Route path="/routines" element={<RoutinesPage />} />
+          <Route path="/challenges" element={<ChallengesPage />} />
+          <Route path="/feed" element={<FeedPage />} />
+          <Route path="/statistics" element={<StatisticsPage />} />
+          <Route path="/notifications" element={<NotificationsPage />} />
           <Route path="/profile" element={<ProfilePage />} />
         </Route>
       </Route>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { Routes, Route } from 'react-router-dom'
 import { useInitAuth } from '@/hooks/useInitAuth'
 import ProtectedRoute from '@/components/common/ProtectedRoute'
 import PublicOnlyRoute from '@/components/common/PublicOnlyRoute'
+import AppLayout from '@/components/layout/AppLayout'
 import LoginPage from '@/pages/LoginPage'
 import SignupPage from '@/pages/SignupPage'
 import HomePage from '@/pages/HomePage'
@@ -19,8 +20,10 @@ export default function App() {
       </Route>
 
       <Route element={<ProtectedRoute />}>
-        <Route path="/" element={<HomePage />} />
-        <Route path="/profile" element={<ProfilePage />} />
+        <Route element={<AppLayout />}>
+          <Route path="/" element={<HomePage />} />
+          <Route path="/profile" element={<ProfilePage />} />
+        </Route>
       </Route>
 
       <Route path="*" element={<NotFoundPage />} />

--- a/src/components/common/Logo.tsx
+++ b/src/components/common/Logo.tsx
@@ -1,0 +1,64 @@
+interface RoutinelyMarkProps {
+  size?: number
+  color?: string
+  check?: string
+  dotOuter?: string
+  dotInner?: string
+}
+
+export function RoutinelyMark({
+  size = 40,
+  color = 'var(--coral-500)',
+  check = '#ffffff',
+  dotOuter = 'var(--coral-700)',
+  dotInner = 'var(--coral-100)',
+}: RoutinelyMarkProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 200 200" fill="none" aria-hidden="true">
+      <rect width="200" height="200" rx="44" fill={color} />
+      <polyline
+        points="46,108 82,144 154,68"
+        stroke={check}
+        strokeWidth="20"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        fill="none"
+      />
+      <circle cx="152" cy="52" r="18" fill={dotOuter} />
+      <circle cx="152" cy="52" r="11" fill={dotInner} />
+    </svg>
+  )
+}
+
+interface RoutinelyWordmarkProps {
+  size?: number
+  color?: string
+  mark?: string
+}
+
+export function RoutinelyWordmark({
+  size = 32,
+  color = 'var(--text)',
+  mark = 'var(--coral-500)',
+}: RoutinelyWordmarkProps) {
+  return (
+    <div
+      style={{ display: 'inline-flex', alignItems: 'center', gap: size * 0.28 }}
+      aria-label="Routinely"
+    >
+      <RoutinelyMark size={size} color={mark} />
+      <span
+        style={{
+          fontFamily: "'Geist', 'Pretendard', sans-serif",
+          fontSize: size * 0.72,
+          fontWeight: 700,
+          letterSpacing: -size * 0.025,
+          color,
+          lineHeight: 1,
+        }}
+      >
+        Routinely<span style={{ color: mark }}>.</span>
+      </span>
+    </div>
+  )
+}

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,0 +1,13 @@
+import { Outlet } from 'react-router-dom'
+import Header from './Header'
+
+export default function AppLayout() {
+  return (
+    <div className="flex flex-col h-screen">
+      <Header />
+      <main className="flex-1 overflow-y-auto" style={{ background: 'var(--bg)' }}>
+        <Outlet />
+      </main>
+    </div>
+  )
+}

--- a/src/components/layout/Header.module.css
+++ b/src/components/layout/Header.module.css
@@ -1,0 +1,176 @@
+.appHeader {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  height: 56px;
+  flex-shrink: 0;
+  column-gap: 18px;
+  padding: 0 24px;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  text-decoration: none;
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: none;
+}
+
+.nav::-webkit-scrollbar {
+  display: none;
+}
+
+.navItem {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  height: 36px;
+  padding: 0 14px;
+  border-radius: 10px;
+  text-decoration: none;
+  white-space: nowrap;
+  transition: color 200ms ease, background-color 200ms ease;
+}
+
+.navItemActive {
+  color: var(--coral-500);
+  font-weight: 700;
+}
+
+.navItemInactive {
+  color: var(--text-muted);
+  font-weight: 600;
+}
+
+.navItem:hover {
+  background: var(--surface-2);
+}
+
+.navContent {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 14px;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.navIndicator {
+  position: absolute;
+  right: 0;
+  bottom: -1px;
+  left: 0;
+  height: 2px;
+  border-radius: 999px;
+  background: var(--coral-500);
+  opacity: 0;
+  transform: scaleX(0);
+  transform-origin: center;
+  transition: transform 200ms ease, opacity 200ms ease;
+}
+
+.navIndicatorActive {
+  opacity: 1;
+  transform: scaleX(1);
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+.iconLink {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 999px;
+  color: var(--text-muted);
+  text-decoration: none;
+  transition: color 200ms ease, background-color 200ms ease;
+}
+
+.iconLink:hover {
+  background: var(--surface-2);
+}
+
+.badge {
+  position: absolute;
+  top: 0;
+  right: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border: 2px solid var(--surface);
+  border-radius: 999px;
+  background: var(--coral-500);
+  color: white;
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 1;
+  pointer-events: none;
+  transform: translate(30%, -20%);
+  box-shadow: 0 0 0 1px var(--surface);
+}
+
+.profile {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  background: #ff8a65;
+  color: white;
+  font-size: 13px;
+  font-weight: 700;
+  font-family: 'Pretendard', sans-serif;
+  text-decoration: none;
+}
+
+@media (max-width: 720px) {
+  .appHeader {
+    height: 52px;
+    column-gap: 12px;
+    padding: 0 16px;
+  }
+
+  .nav {
+    gap: 2px;
+  }
+
+  .navItem {
+    height: 34px;
+    padding: 0 11px;
+  }
+
+  .navContent {
+    gap: 5px;
+    font-size: 13px;
+  }
+
+  .actions {
+    gap: 8px;
+  }
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,0 +1,137 @@
+import type { ReactNode } from 'react'
+import { Link, useLocation } from 'react-router-dom'
+import { useAuthStore } from '@/stores/authStore'
+import { RoutinelyWordmark } from '@/components/common/Logo'
+import { cn } from '@/utils/cn'
+import styles from './Header.module.css'
+
+const NAV_ITEMS = [
+  { id: 'home', label: '홈', path: '/', icon: 'home' },
+  { id: 'routines', label: '내 루틴', path: '/routines', icon: 'repeat' },
+  { id: 'challenges', label: '챌린지', path: '/challenges', icon: 'trophy' },
+  { id: 'feed', label: '피드', path: '/feed', icon: 'feed' },
+  { id: 'stats', label: '통계', path: '/statistics', icon: 'chart' },
+] as const
+
+const ICON_PATHS: Record<string, ReactNode> = {
+  home: <path d="M3 11l9-8 9 8v10a1 1 0 01-1 1h-5v-7h-6v7H4a1 1 0 01-1-1V11z" />,
+  repeat: (
+    <>
+      <path d="M17 1l4 4-4 4" />
+      <path d="M3 11V9a4 4 0 014-4h14" />
+      <path d="M7 23l-4-4 4-4" />
+      <path d="M21 13v2a4 4 0 01-4 4H3" />
+    </>
+  ),
+  trophy: (
+    <>
+      <path d="M8 4h8v6a4 4 0 01-8 0V4z" />
+      <path d="M16 6h3v2a3 3 0 01-3 3M8 6H5v2a3 3 0 003 3" />
+      <path d="M9 19h6M10 14v5h4v-5" />
+    </>
+  ),
+  feed: <path d="M4 6h16M4 12h10M4 18h16" />,
+  chart: (
+    <>
+      <path d="M3 21h18" />
+      <rect x="5" y="11" width="3" height="8" />
+      <rect x="11" y="6" width="3" height="13" />
+      <rect x="17" y="14" width="3" height="5" />
+    </>
+  ),
+  bell: (
+    <>
+      <path d="M6 8a6 6 0 0112 0c0 7 3 9 3 9H3s3-2 3-9z" />
+      <path d="M10 21a2 2 0 004 0" />
+    </>
+  ),
+}
+
+function NavIcon({ name }: { name: string }) {
+  return (
+    <svg
+      width={16}
+      height={16}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.8}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      {ICON_PATHS[name]}
+    </svg>
+  )
+}
+
+function BellIcon() {
+  return (
+    <svg
+      width={20}
+      height={20}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.8}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      {ICON_PATHS.bell}
+    </svg>
+  )
+}
+
+export default function Header() {
+  const { pathname } = useLocation()
+  const { user } = useAuthStore()
+  const notificationCount = 0
+
+  const isActive = (path: string): boolean => {
+    if (path === '/') return pathname === '/'
+    return pathname.startsWith(path)
+  }
+
+  const initial = user?.nickname?.[0] ?? '?'
+
+  return (
+    <header className={styles.appHeader}>
+      <Link to="/" aria-label="홈으로" className={styles.brand}>
+        <RoutinelyWordmark size={24} />
+      </Link>
+
+      <nav className={styles.nav} aria-label="주 메뉴">
+        {NAV_ITEMS.map((item) => {
+          const active = isActive(item.path)
+          return (
+            <Link
+              key={item.id}
+              to={item.path}
+              className={cn(styles.navItem, active ? styles.navItemActive : styles.navItemInactive)}
+            >
+              <div className={styles.navContent}>
+                <NavIcon name={item.icon} />
+                {item.label}
+              </div>
+              <div className={cn(styles.navIndicator, active && styles.navIndicatorActive)} />
+            </Link>
+          )
+        })}
+      </nav>
+
+      <div className={styles.actions}>
+        <Link to="/notifications" aria-label="알림" className={styles.iconLink}>
+          <BellIcon />
+          {notificationCount > 0 && (
+            <span className={styles.badge}>{notificationCount}</span>
+          )}
+        </Link>
+
+        <Link to="/profile" aria-label="프로필" className={styles.profile}>
+          {initial}
+        </Link>
+      </div>
+    </header>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,15 +1,91 @@
+@import url('https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700;800&display=swap');
+@import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.css');
 @import "tailwindcss";
 
+/* ── Raw design tokens ─────────────────────────────────── */
+:root {
+  --coral-50:  #fff4ef;
+  --coral-100: #ffe5d8;
+  --coral-200: #ffcab1;
+  --coral-300: #ffa37e;
+  --coral-400: #ff7a4d;
+  --coral-500: #ff5a2b;
+  --coral-600: #ed3d11;
+  --coral-700: #c52d0c;
+  --sunset-300: #ffd166;
+  --sunset-500: #ff9248;
+
+  --ink-0:   #ffffff;
+  --ink-25:  #fafaf7;
+  --ink-50:  #f5f4ef;
+  --ink-100: #ebe9e2;
+  --ink-200: #dcd8cf;
+  --ink-300: #b8b3a6;
+  --ink-400: #88847a;
+  --ink-500: #5d5a52;
+  --ink-600: #3d3a34;
+  --ink-700: #28251f;
+  --ink-800: #1a1814;
+  --ink-900: #0f0e0b;
+
+  /* Semantic surfaces (light) */
+  --bg:            var(--ink-25);
+  --surface:       var(--ink-0);
+  --surface-2:     var(--ink-50);
+  --border:        var(--ink-100);
+  --border-strong: var(--ink-200);
+  --text:          var(--ink-800);
+  --text-muted:    var(--ink-500);
+  --text-dim:      var(--ink-400);
+
+  --success:    #16a34a;
+  --success-bg: #d6f5e1;
+  --warning:    #f59e0b;
+  --danger:     #dc2626;
+  --info:       #2563eb;
+
+  --sh-1: 0 1px 2px rgba(20,18,12,.05), 0 1px 1px rgba(20,18,12,.04);
+  --sh-2: 0 2px 6px rgba(20,18,12,.06), 0 4px 16px rgba(20,18,12,.05);
+  --sh-3: 0 8px 24px rgba(20,18,12,.08), 0 12px 40px rgba(20,18,12,.08);
+  --sh-coral: 0 8px 24px rgba(255,90,43,.28), 0 2px 6px rgba(255,90,43,.18);
+}
+
+[data-theme="dark"] {
+  --bg:            #0f0e0b;
+  --surface:       #1a1814;
+  --surface-2:     #232019;
+  --border:        #2c2922;
+  --border-strong: #3a3629;
+  --text:          #f5f4ef;
+  --text-muted:    #a8a499;
+  --text-dim:      #6b675c;
+}
+
+/* ── Tailwind v4 theme → utility classes ───────────────── */
 @theme {
-  --color-primary: #dc3545;
-  --color-primary-tint: #fdeaec;
-  --color-success: #10b981;
+  --color-coral-50:   #fff4ef;
+  --color-coral-100:  #ffe5d8;
+  --color-coral-200:  #ffcab1;
+  --color-coral-400:  #ff7a4d;
+  --color-coral-500:  #ff5a2b;
+  --color-coral-600:  #ed3d11;
+  --color-coral-700:  #c52d0c;
+  --color-sunset-500: #ff9248;
+
+  --color-ink-100: #ebe9e2;
+  --color-ink-200: #dcd8cf;
+  --color-ink-400: #88847a;
+  --color-ink-500: #5d5a52;
+  --color-ink-600: #3d3a34;
+  --color-ink-800: #1a1814;
+  --color-ink-900: #0f0e0b;
+
+  --color-success: #16a34a;
   --color-warning: #f59e0b;
-  --color-text-primary: #111827;
-  --color-text-secondary: #6b7280;
-  --color-bg-page: #fafafa;
-  --color-bg-card: #ffffff;
-  --color-border: #e5e7eb;
+  --color-danger:  #dc2626;
+  --color-info:    #2563eb;
+
+  --font-sans: 'Geist', 'Pretendard', system-ui, sans-serif;
 }
 
 * {
@@ -19,8 +95,9 @@
 }
 
 body {
-  background-color: #fafafa;
-  color: #111827;
-  font-family: system-ui, -apple-system, sans-serif;
+  background-color: var(--bg);
+  color: var(--text);
+  font-family: 'Geist', 'Pretendard', system-ui, sans-serif;
   -webkit-font-smoothing: antialiased;
+  font-feature-settings: 'cv11', 'ss01', 'ss03';
 }

--- a/src/pages/ChallengesPage.tsx
+++ b/src/pages/ChallengesPage.tsx
@@ -1,0 +1,3 @@
+export default function ChallengesPage() {
+  return <div className="p-4 text-text-primary">챌린지</div>
+}

--- a/src/pages/FeedPage.tsx
+++ b/src/pages/FeedPage.tsx
@@ -1,0 +1,3 @@
+export default function FeedPage() {
+  return <div className="p-4 text-text-primary">피드</div>
+}

--- a/src/pages/NotificationsPage.tsx
+++ b/src/pages/NotificationsPage.tsx
@@ -1,0 +1,3 @@
+export default function NotificationsPage() {
+  return <div className="p-4 text-text-primary">알림</div>
+}

--- a/src/pages/RoutinesPage.tsx
+++ b/src/pages/RoutinesPage.tsx
@@ -1,0 +1,3 @@
+export default function RoutinesPage() {
+  return <div className="p-4 text-text-primary">내 루틴</div>
+}

--- a/src/pages/StatisticsPage.tsx
+++ b/src/pages/StatisticsPage.tsx
@@ -1,0 +1,3 @@
+export default function StatisticsPage() {
+  return <div className="p-4 text-text-primary">통계</div>
+}


### PR DESCRIPTION
## ✅ 무엇을 변경했나요?
- 인증 사용자 영역에 공통 `AppLayout` shell 추가
- design/v2 기준의 상단 `Header` 네비게이션 구현
- 헤더에서 연결되는 주요 경로에 placeholder page/route 연결
- 인증 영역의 잘못된 경로는 `AppLayout` 내부 404로 렌더링되도록 정리

## 🎯 왜 변경했나요? (문제/배경)
- 이 PR이 해결하는 문제: 인증 이후 모든 페이지에서 공통으로 사용할 레이아웃 및 네비게이션이 없었음
- 관련 맥락/배경: design/v2 스펙 기준, 상단 헤더 + 콘텐츠 영역 구조로 정의된 shell 구현

## 🔗 관련 이슈
- Closes #8

## 🧪 테스트/검증 방법
- [x] 로컬 빌드/실행 확인
- [x] 핵심 시나리오 수동 테스트
- [ ] (선택) 단위/통합 테스트 추가 또는 수정

### 검증 시나리오
1. `npm run build` 통과 확인
2. 헤더 탭 클릭 시 404 대신 각 placeholder route로 이동하는 것 확인
3. 인증 영역의 잘못된 경로가 헤더를 유지한 채 404로 보이는 것 확인

## 📸 스크린샷/로그 (선택)

## ✅ 체크리스트
- [x] 코드가 컴파일/빌드 됩니다
- [x] 불필요한 디버그 코드/로그를 제거했습니다
- [x] 에러 케이스를 고려했습니다
- [ ] (필요 시) 문서/주석을 업데이트했습니다
- [x] (Front-end) UI/상태 변경이 의도대로 동작합니다

## 📝 기타 공유사항 (선택)
- 리뷰 시 참고할 점:
  - design/v2 기준으로 `BottomNav`는 이번 PR에서 제외했습니다.
  - 신규 페이지들은 실제 기능 구현 전까지 shell/placeholder 성격입니다.
  - 알림 배지는 정적 shell만 구현했고, 추후 `notification-service` 연동 시 실제 count를 연결할 예정입니다.
- 후속 작업(To-do):
  - 각 placeholder 페이지 실제 기능 구현
  - 알림 배지 `notification-service` 연동