### PR TITLE
[feat] #11 로그인·회원가입 페이지 구현

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,47 +2,66 @@
 
 ## 1. 기술 스택
 
-| 항목 | 선택 | 비고 |
-|---|---|---|
-| Language | TypeScript | strict 모드 권장 |
-| Framework | React 19 | |
-| Build Tool | Vite | |
-| Routing | React Router v7 | SPA 라우팅 |
-| 서버 상태 관리 | React Query (TanStack Query) | 캐싱, 로딩, 리트라이 |
-| 전역 상태 관리 | Zustand | 로그인 사용자, 토스트, UI 상태만 |
-| HTTP 클라이언트 | axios | interceptor로 토큰 자동 첨부 |
-| 실시간 채팅 | STOMP over WebSocket | `@stomp/stompjs` |
-| 실시간 알림 | SSE (EventSource) | 서버 → 클라이언트 단방향 |
-| UI 시스템 | Tailwind CSS + shadcn/ui | |
-| 폼 관리 | React Hook Form + Zod | |
-| 디자인 시스템 | Bold Editorial + 코랄 포인트 (`#ff5a2b`) | `design/v2/` 참고 |
+| 항목            | 선택                                     | 비고                                |
+| --------------- | ---------------------------------------- | ----------------------------------- |
+| Language        | TypeScript                               | strict 모드 권장                    |
+| Framework       | React 19                                 |                                     |
+| Build Tool      | Vite                                     |                                     |
+| Routing         | React Router v7                          | SPA 라우팅                          |
+| 서버 상태 관리  | React Query (TanStack Query)             | 캐싱, 로딩, 리트라이                |
+| 전역 상태 관리  | Zustand                                  | 로그인 사용자, 토스트, UI 상태만    |
+| HTTP 클라이언트 | axios                                    | interceptor로 토큰 자동 첨부        |
+| 실시간 채팅     | STOMP over WebSocket                     | `@stomp/stompjs`                    |
+| 실시간 알림     | SSE (EventSource)                        | 서버 → 클라이언트 단방향            |
+| UI 시스템       | Tailwind CSS + shadcn/ui                 |                                     |
+| 폼 관리         | React Hook Form + Zod                    |                                     |
+| 디자인 시스템   | Bold Editorial + 코랄 포인트 (`#ff5a2b`) | `design/{최신버전}/` 참고 (아래 §3) |
 
 ---
 
 ## 2. 라우팅 구조
 
-| 경로 | 페이지 | 인증 필요 |
-|---|---|:---:|
-| `/login` | 로그인 | ❌ |
-| `/signup` | 회원가입 | ❌ |
-| `/` | 홈 (루틴 현황 + 챌린지 요약 + 알림) | ✅ |
-| `/routines` | 내 루틴 목록 | ✅ |
-| `/routines/new` | 루틴 생성 | ✅ |
-| `/routines/:id` | 루틴 상세 | ✅ |
-| `/challenges` | 챌린지 목록 | ✅ |
-| `/challenges/new` | 챌린지 생성 | ✅ |
-| `/challenges/:id` | 챌린지 상세 (피드 + 랭킹) | ✅ |
-| `/challenges/:id/chat` | 챌린지 채팅방 | ✅ |
-| `/feed` | 개인 피드 | ✅ |
-| `/statistics` | 개인 통계 / 스트릭 | ✅ |
-| `/notifications` | 알림 목록 | ✅ |
-| `/profile` | 내 프로필 | ✅ |
+| 경로                   | 페이지                              | 인증 필요 |
+| ---------------------- | ----------------------------------- | :-------: |
+| `/login`               | 로그인                              |    ❌     |
+| `/signup`              | 회원가입                            |    ❌     |
+| `/`                    | 홈 (루틴 현황 + 챌린지 요약 + 알림) |    ✅     |
+| `/routines`            | 내 루틴 목록                        |    ✅     |
+| `/routines/new`        | 루틴 생성                           |    ✅     |
+| `/routines/:id`        | 루틴 상세                           |    ✅     |
+| `/challenges`          | 챌린지 목록                         |    ✅     |
+| `/challenges/new`      | 챌린지 생성                         |    ✅     |
+| `/challenges/:id`      | 챌린지 상세 (피드 + 랭킹)           |    ✅     |
+| `/challenges/:id/chat` | 챌린지 채팅방                       |    ✅     |
+| `/feed`                | 개인 피드                           |    ✅     |
+| `/statistics`          | 개인 통계 / 스트릭                  |    ✅     |
+| `/notifications`       | 알림 목록                           |    ✅     |
+| `/profile`             | 내 프로필                           |    ✅     |
 
 ---
 
 ## 3. 디자인 시스템
 
-> 상세 내용은 `design/v2/Routinely.html`을 브라우저로 열어 확인 / 토큰 정의는 `design/v2/tokens.css`
+### 디자인 버전 관리 규칙
+
+> **항상 `design/` 폴더에서 가장 높은 버전 디렉토리를 참조할 것.**
+> 버전 확인 방법: `ls design/` → 가장 큰 번호 (예: v2 → v3이 생기면 v3 사용)
+> 현재 최신 버전: **v2**
+
+각 버전 디렉토리의 구성:
+
+| 파일                     | 역할                                                |
+| ------------------------ | --------------------------------------------------- |
+| `Routinely.html`         | 전체 디자인 캔버스 (브라우저에서 열어 확인)         |
+| `tokens.css`             | CSS 변수 토큰 정의 (색상, 폰트, radius, shadow)     |
+| `icons.jsx`              | 인라인 SVG 아이콘 라이브러리 + 로고 컴포넌트        |
+| `artboards-system.jsx`   | 로고/컬러/타이포그래피/컴포넌트 쇼케이스            |
+| `artboards-home.jsx`     | 로그인, 회원가입, 홈 대시보드, `AppHeader` 컴포넌트 |
+| `artboards-routines.jsx` | 루틴 목록/상세/완료/생성, 챌린지 상세/브라우저      |
+| `artboards-feed.jsx`     | 피드, 채팅, 통계, 알림, 프로필                      |
+| `artboards-proto.jsx`    | 클릭 가능한 인터랙티브 프로토타입                   |
+
+화면 개발 전, 해당 화면의 artboard 파일을 **반드시 먼저 읽고** 구현한다.
 
 ### 핵심 원칙
 
@@ -51,30 +70,45 @@
 - **의미 있는 색상 사용** — 완료=`#16a34a`, 경고=`#f59e0b`, 위험=`#dc2626`
 - **폰트** — Geist (영문·숫자), Pretendard (한글)
 
+### 네비게이션 구조 (AppHeader)
+
+v2 디자인의 네비게이션은 **상단 수평 탭** 방식이다.
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ [로고]  홈  내 루틴  챌린지  피드  통계      [🔔] [아바타] │  ← 높이 64px
+└─────────────────────────────────────────────────────────┘
+```
+
+- 활성 탭: `background: var(--surface-2)`, 텍스트 색 `var(--text)`
+- 비활성 탭: `color: var(--text-muted)`, 배경 투명
+- 알림 배지: `background: var(--coral-500)`, 우측 상단 dot
+- 전체 헤더: `background: var(--surface)`, `border-bottom: 1px solid var(--border)`
+
 ### 핵심 색상 토큰
 
-| 토큰 | 값 | 사용처 |
-|---|---|---|
-| `--coral-500` | `#ff5a2b` | CTA 버튼, 활성 메뉴, 진행률 바, 알림 배지 |
-| `--coral-100` | `#ffe5d8` | 활성 메뉴 배경, 배지 배경 |
-| `--sunset-500` | `#ff9248` | 그라디언트 끝 색상 |
-| `--success` | `#16a34a` | 완료 상태, 체크 아이콘 |
-| `--warning` | `#f59e0b` | 미완료, 마감 임박(D-3 이하) |
-| `--text` | `#1a1814` | 제목, 본문 |
-| `--text-muted` | `#5d5a52` | 보조 텍스트, 날짜 |
-| `--bg` | `#fafaf7` | 페이지 배경 |
-| `--surface` | `#ffffff` | 카드 배경 |
-| `--border` | `#ebe9e2` | 기본 테두리 |
+| 토큰           | 값        | 사용처                                    |
+| -------------- | --------- | ----------------------------------------- |
+| `--coral-500`  | `#ff5a2b` | CTA 버튼, 활성 메뉴, 진행률 바, 알림 배지 |
+| `--coral-100`  | `#ffe5d8` | 활성 메뉴 배경, 배지 배경                 |
+| `--sunset-500` | `#ff9248` | 그라디언트 끝 색상                        |
+| `--success`    | `#16a34a` | 완료 상태, 체크 아이콘                    |
+| `--warning`    | `#f59e0b` | 미완료, 마감 임박(D-3 이하)               |
+| `--text`       | `#1a1814` | 제목, 본문                                |
+| `--text-muted` | `#5d5a52` | 보조 텍스트, 날짜                         |
+| `--bg`         | `#fafaf7` | 페이지 배경                               |
+| `--surface`    | `#ffffff` | 카드 배경                                 |
+| `--border`     | `#ebe9e2` | 기본 테두리                               |
 
 ### 진행률 바 색상 규칙
 
-| 달성률 | 색상 |
-|---|---|
-| 0% | `--ink-100` |
-| 1~49% | `--sunset-500` |
-| 50~79% | `--coral-500` |
-| 80~99% | `--coral-500` |
-| 100% | `--success` |
+| 달성률 | 색상           |
+| ------ | -------------- |
+| 0%     | `--ink-100`    |
+| 1~49%  | `--sunset-500` |
+| 50~79% | `--coral-500`  |
+| 80~99% | `--coral-500`  |
+| 100%   | `--success`    |
 
 ---
 
@@ -92,13 +126,13 @@
 
 ## 5. 상태 관리 원칙
 
-| 상태 종류 | 관리 방법 |
-|---|---|
-| 서버 데이터 (API 응답) | React Query |
-| 전역 UI 상태 | Zustand (로그인 정보, accessToken, 토스트) |
-| 로컬 UI 상태 | useState / useReducer |
-| 실시간 채팅 메시지 | useState + STOMP 훅 |
-| 실시간 알림 | SSE + Zustand (미읽음 수) |
+| 상태 종류              | 관리 방법                                  |
+| ---------------------- | ------------------------------------------ |
+| 서버 데이터 (API 응답) | React Query                                |
+| 전역 UI 상태           | Zustand (로그인 정보, accessToken, 토스트) |
+| 로컬 UI 상태           | useState / useReducer                      |
+| 실시간 채팅 메시지     | useState + STOMP 훅                        |
+| 실시간 알림            | SSE + Zustand (미읽음 수)                  |
 
 **원칙**: React Query로 관리 가능한 서버 데이터는 Zustand에 복사하지 않는다.
 
@@ -122,7 +156,7 @@
 
 ## 7. 주의사항
 
-- **디자인 레퍼런스 준수** — 화면 개발 시 `design/v2/Routinely.html` 기준으로 구현
+- **디자인 레퍼런스 준수** — 화면 개발 시 `design/{최신버전}/` 참조 (§3 버전 확인 규칙 준수)
 - **React Query 우선** — API 데이터는 React Query로 관리, Zustand에 복사 금지
 - **MVP에서 구현하지 않는 것**: 소셜 로그인 UI, 피드 댓글, 프로필 이미지 업로드
 - **환경 변수**: `VITE_` 접두사 필수 — `VITE_API_BASE_URL`, `VITE_WS_URL`

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,0 +1,21 @@
+import { apiClient } from './client'
+import type { ApiResponse } from '@/types/api'
+import type { LoginRequest, LoginResponse, SignupRequest, SignupResponse } from '@/types/auth'
+
+function unwrapApiResponse<T>(response: ApiResponse<T>, fallbackMessage: string): T {
+  if (response.success && response.data) {
+    return response.data
+  }
+
+  throw new Error(response.message || fallbackMessage)
+}
+
+export async function postSignup(data: SignupRequest): Promise<SignupResponse> {
+  const res = await apiClient.post<ApiResponse<SignupResponse>>('/auth/signup', data)
+  return unwrapApiResponse(res.data, '회원가입에 실패했습니다.')
+}
+
+export async function postLogin(data: LoginRequest): Promise<LoginResponse> {
+  const res = await apiClient.post<ApiResponse<LoginResponse>>('/auth/login', data)
+  return unwrapApiResponse(res.data, '로그인에 실패했습니다.')
+}

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,7 +1,8 @@
 import axios, { type InternalAxiosRequestConfig } from 'axios'
 
 import { useAuthStore } from '@/stores/authStore'
-import type { ApiResponse, RefreshResponse } from '@/types/api'
+import type { ApiResponse } from '@/types/api'
+import type { AuthSessionResponse } from '@/types/auth'
 
 const apiBaseUrl = import.meta.env.VITE_API_BASE_URL
 
@@ -64,7 +65,11 @@ apiClient.interceptors.response.use(
     const originalRequest = error.config as RetryableConfig
 
     // refresh/logout 자체의 401은 처리하지 않음 (데드락/무한루프 방지)
-    if (originalRequest.url === '/auth/refresh' || originalRequest.url === '/auth/logout') {
+    if (
+      originalRequest.url === '/auth/refresh' ||
+      originalRequest.url === '/auth/logout' ||
+      originalRequest.url === '/auth/login'
+    ) {
       return Promise.reject(error)
     }
 
@@ -87,13 +92,13 @@ apiClient.interceptors.response.use(
     isRefreshing = true
 
     try {
-      const { data } = await apiClient.post<ApiResponse<RefreshResponse>>('/auth/refresh')
-      const newToken = data.data!.accessToken
+      const { data } = await apiClient.post<ApiResponse<AuthSessionResponse>>('/auth/refresh')
+      const session = data.data!
 
-      useAuthStore.getState().setAccessToken(newToken)
-      processQueue(null, newToken)
+      useAuthStore.getState().setAuth(session.accessToken, session.user)
+      processQueue(null, session.accessToken)
 
-      return retryRequest(originalRequest, newToken)
+      return retryRequest(originalRequest, session.accessToken)
     } catch (refreshError) {
       processQueue(refreshError)
       useAuthStore.getState().clearAuth()

--- a/src/components/auth/AuthIntro.tsx
+++ b/src/components/auth/AuthIntro.tsx
@@ -1,0 +1,55 @@
+interface AuthIntroProps {
+  eyebrow?: string
+  title: React.ReactNode
+  description: string
+  containerMarginTop: number
+  titleMarginTop: number
+  titleFontSize: number
+  titleLetterSpacing: string
+  descriptionMarginTop: number
+}
+
+export default function AuthIntro({
+  eyebrow,
+  title,
+  description,
+  containerMarginTop,
+  titleMarginTop,
+  titleFontSize,
+  titleLetterSpacing,
+  descriptionMarginTop,
+}: AuthIntroProps) {
+  return (
+    <div style={{ marginTop: containerMarginTop }}>
+      {eyebrow && (
+        <div
+          style={{
+            fontSize: 11,
+            letterSpacing: '.14em',
+            textTransform: 'uppercase',
+            fontWeight: 700,
+            color: 'var(--coral-600)',
+          }}
+        >
+          {eyebrow}
+        </div>
+      )}
+
+      <h1
+        style={{
+          fontSize: titleFontSize,
+          lineHeight: 1.05,
+          letterSpacing: titleLetterSpacing,
+          fontWeight: 700,
+          marginTop: titleMarginTop,
+        }}
+      >
+        {title}
+      </h1>
+
+      <p style={{ color: 'var(--text-muted)', marginTop: descriptionMarginTop, fontSize: 15 }}>
+        {description}
+      </p>
+    </div>
+  )
+}

--- a/src/components/auth/AuthShell.module.css
+++ b/src/components/auth/AuthShell.module.css
@@ -1,0 +1,153 @@
+.shell {
+  min-height: 100svh;
+  height: 100svh;
+  display: flex;
+  background: var(--bg);
+  overflow: hidden;
+}
+
+.formPane {
+  flex: 1;
+  max-width: 520px;
+  padding: 60px 72px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  overflow-y: auto;
+}
+
+.hero {
+  flex: 1.1;
+  background: linear-gradient(140deg, var(--coral-500), var(--sunset-500));
+  padding: 60px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  position: relative;
+  overflow: hidden;
+}
+
+.heroOrb {
+  position: absolute;
+  border-radius: 50%;
+  pointer-events: none;
+}
+
+.heroTop {
+  color: rgba(255, 255, 255, 0.8);
+  font-weight: 600;
+  font-size: 13px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  position: relative;
+}
+
+.heroBottom {
+  position: relative;
+}
+
+.heroNumber {
+  font-size: 130px;
+  line-height: 1;
+  font-weight: 700;
+  color: white;
+  letter-spacing: -0.04em;
+}
+
+.heroFire {
+  font-size: 50px;
+  margin-left: 8px;
+}
+
+.heroQuote {
+  color: rgba(255, 255, 255, 0.95);
+  font-size: 22px;
+  font-weight: 500;
+  margin-top: 12px;
+  max-width: 440px;
+  line-height: 1.3;
+  text-wrap: balance;
+}
+
+.heroSocialProof {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 28px;
+}
+
+.avatarStack {
+  display: flex;
+}
+
+.avatarItem {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  font-size: 14px;
+  font-weight: 700;
+  border: 2px solid var(--surface);
+  margin-left: -10px;
+  flex-shrink: 0;
+}
+
+.avatarItem:first-child {
+  margin-left: 0;
+}
+
+.heroSub {
+  color: white;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.shellCentered {
+  min-height: 100svh;
+  background: var(--bg);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 50px 24px;
+}
+
+.centeredInner {
+  width: 100%;
+  max-width: 480px;
+}
+
+@media (max-width: 860px) {
+  .shell {
+    height: auto;
+    flex-direction: column;
+    overflow: visible;
+  }
+
+  .formPane {
+    max-width: 100%;
+    padding: 48px 32px;
+    justify-content: flex-start;
+    overflow-y: visible;
+  }
+
+  .hero {
+    min-height: 220px;
+    padding: 36px 32px;
+  }
+
+  .heroNumber {
+    font-size: 72px;
+  }
+
+  .heroFire {
+    font-size: 32px;
+  }
+
+  .heroQuote {
+    font-size: 16px;
+    margin-top: 8px;
+  }
+}

--- a/src/components/auth/AuthShell.tsx
+++ b/src/components/auth/AuthShell.tsx
@@ -1,0 +1,63 @@
+import styles from './AuthShell.module.css'
+
+interface Props {
+  variant: 'split' | 'centered'
+  children: React.ReactNode
+}
+
+function HeroPanel() {
+  return (
+    <div className={styles.hero}>
+      <div
+        className={styles.heroOrb}
+        style={{ top: -100, right: -100, width: 400, height: 400, border: '2px solid rgba(255,255,255,.15)' }}
+      />
+      <div
+        className={styles.heroOrb}
+        style={{ bottom: -150, left: -50, width: 500, height: 500, border: '2px solid rgba(255,255,255,.1)' }}
+      />
+      <div className={styles.heroTop}>Streak · Day 21</div>
+      <div className={styles.heroBottom}>
+        <div className={styles.heroNumber}>
+          21<span className={styles.heroFire}>🔥</span>
+        </div>
+        <p className={styles.heroQuote}>
+          "가장 어려운 건 시작이 아니라,
+          <br />
+          어제도 했다는 사실을 오늘 기억하는 일이에요."
+        </p>
+        <div className={styles.heroSocialProof}>
+          <div className={styles.avatarStack} aria-hidden="true">
+            <div className={styles.avatarItem} style={{ background: '#ffd166' }}>
+              지
+            </div>
+            <div className={styles.avatarItem} style={{ background: '#06d6a0' }}>
+              민
+            </div>
+            <div className={styles.avatarItem} style={{ background: '#118ab2' }}>
+              준
+            </div>
+          </div>
+          <div className={styles.heroSub}>2,341명이 오늘 인증 완료</div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default function AuthShell({ variant, children }: Props) {
+  if (variant === 'split') {
+    return (
+      <div className={styles.shell}>
+        <div className={styles.formPane}>{children}</div>
+        <HeroPanel />
+      </div>
+    )
+  }
+
+  return (
+    <div className={styles.shellCentered}>
+      <div className={styles.centeredInner}>{children}</div>
+    </div>
+  )
+}

--- a/src/components/auth/PasswordField.tsx
+++ b/src/components/auth/PasswordField.tsx
@@ -1,0 +1,137 @@
+import { useState, type ChangeEvent, type ClipboardEvent, type InputHTMLAttributes } from 'react'
+import styles from './authForm.module.css'
+
+interface PasswordFieldProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type'> {
+  errorMessage?: string
+}
+
+const ASCII_PRINTABLE_PATTERN = /[ -~]/g
+
+export default function PasswordField({
+  errorMessage,
+  className,
+  onChange,
+  onPaste,
+  ...props
+}: PasswordFieldProps) {
+  const [isVisible, setIsVisible] = useState(false)
+  const inputClassName = [styles.input, errorMessage ? styles.inputError : '', className]
+    .filter(Boolean)
+    .join(' ')
+
+  const sanitizeValue = (value: string) => value.match(ASCII_PRINTABLE_PATTERN)?.join('') ?? ''
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const sanitizedValue = sanitizeValue(event.currentTarget.value)
+
+    if (sanitizedValue !== event.currentTarget.value) {
+      event.currentTarget.value = sanitizedValue
+    }
+
+    onChange?.(event)
+  }
+
+  const handlePaste = (event: ClipboardEvent<HTMLInputElement>) => {
+    const pastedText = event.clipboardData.getData('text')
+    const sanitizedText = sanitizeValue(pastedText)
+
+    if (sanitizedText !== pastedText) {
+      event.preventDefault()
+
+      const input = event.currentTarget
+      const selectionStart = input.selectionStart ?? input.value.length
+      const selectionEnd = input.selectionEnd ?? input.value.length
+      const nextValue =
+        input.value.slice(0, selectionStart) + sanitizedText + input.value.slice(selectionEnd)
+
+      input.value = nextValue
+      input.setSelectionRange(
+        selectionStart + sanitizedText.length,
+        selectionStart + sanitizedText.length,
+      )
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+      return
+    }
+
+    onPaste?.(event)
+  }
+
+  return (
+    <div className={styles.field}>
+      <div className={styles.passwordInputWrap}>
+        <input
+          {...props}
+          type={isVisible ? 'text' : 'password'}
+          className={inputClassName}
+          autoCapitalize="none"
+          autoCorrect="off"
+          spellCheck={false}
+          lang="en"
+          onChange={handleChange}
+          onPaste={handlePaste}
+        />
+        <button
+          type="button"
+          className={styles.passwordToggle}
+          onClick={() => setIsVisible((prev) => !prev)}
+          aria-label={isVisible ? '비밀번호 숨기기' : '비밀번호 보기'}
+          aria-pressed={isVisible}
+        >
+          {isVisible ? <EyeOffIcon /> : <EyeIcon />}
+        </button>
+      </div>
+
+      {errorMessage && <span className={styles.fieldError}>{errorMessage}</span>}
+    </div>
+  )
+}
+
+function EyeIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path
+        d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6S2 12 2 12Z"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <circle cx="12" cy="12" r="3" stroke="currentColor" strokeWidth="1.8" />
+    </svg>
+  )
+}
+
+function EyeOffIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path
+        d="M3 3l18 18"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M10.58 10.58A2 2 0 0010 12a2 2 0 003.42 1.42"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M9.88 5.09A11.2 11.2 0 0112 5c6.5 0 10 7 10 7a17.62 17.62 0 01-4.04 4.94"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M6.61 6.61C3.73 8.43 2 12 2 12a17.73 17.73 0 004.03 4.94A10.9 10.9 0 0012 19c1.54 0 2.95-.28 4.22-.77"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}

--- a/src/components/auth/authForm.module.css
+++ b/src/components/auth/authForm.module.css
@@ -1,0 +1,143 @@
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.passwordInputWrap {
+  position: relative;
+}
+
+.input {
+  width: 100%;
+  padding: 11px 48px 11px 14px;
+  border-radius: 10px;
+  border: 1.5px solid var(--border-strong);
+  background: var(--surface);
+  color: var(--text);
+  font-size: 14px;
+  font-family: inherit;
+  outline: none;
+  transition: border-color 150ms, box-shadow 150ms;
+}
+
+.input:focus {
+  border-color: var(--coral-500);
+  box-shadow: 0 0 0 3px var(--coral-100);
+}
+
+.input::placeholder {
+  color: var(--text-dim);
+}
+
+.inputError {
+  border-color: var(--danger);
+}
+
+.inputError:focus {
+  border-color: var(--danger);
+  box-shadow: 0 0 0 3px rgba(220, 38, 38, 0.1);
+}
+
+.fieldError {
+  font-size: 12px;
+  color: var(--danger);
+  font-weight: 500;
+}
+
+.passwordToggle {
+  position: absolute;
+  top: 50%;
+  right: 12px;
+  transform: translateY(-50%);
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-dim);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  pointer-events: none;
+  transition: color 150ms, opacity 150ms;
+}
+
+.passwordInputWrap:focus-within .passwordToggle {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.passwordToggle:hover {
+  color: var(--text-muted);
+}
+
+.passwordToggle:focus-visible {
+  outline: none;
+  color: var(--coral-600);
+}
+
+.passwordToggle svg {
+  width: 20px;
+  height: 20px;
+}
+
+.rootError {
+  padding: 10px 14px;
+  border-radius: 10px;
+  background: #fff1f0;
+  border: 1px solid #ffccc7;
+  font-size: 13px;
+  color: var(--danger);
+  font-weight: 500;
+}
+
+.submitBtn {
+  width: 100%;
+  padding: 13px 0;
+  border-radius: 12px;
+  background: var(--coral-500);
+  color: white;
+  font-weight: 700;
+  font-size: 15px;
+  border: none;
+  cursor: pointer;
+  box-shadow: var(--sh-coral);
+  transition: background 150ms, opacity 150ms;
+  font-family: inherit;
+  margin-top: 8px;
+}
+
+.submitBtn:hover:not(:disabled) {
+  background: var(--coral-600);
+}
+
+.submitBtn:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
+.footer {
+  font-size: 13px;
+  color: var(--text-muted);
+  text-align: center;
+  margin-top: 14px;
+}
+
+.footerLink {
+  color: var(--coral-600);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.footerLink:hover {
+  text-decoration: underline;
+}

--- a/src/components/auth/authFormErrors.ts
+++ b/src/components/auth/authFormErrors.ts
@@ -1,0 +1,22 @@
+import axios from 'axios'
+import type { FieldValues, Path, UseFormSetError } from 'react-hook-form'
+import type { ApiResponse } from '@/types/api'
+
+export type ValidationFieldErrors = Record<string, string>
+
+export function getApiErrorPayload<T>(error: unknown): ApiResponse<T> | null {
+  if (!axios.isAxiosError<ApiResponse<T>>(error)) {
+    return null
+  }
+
+  return error.response?.data ?? null
+}
+
+export function applyValidationFieldErrors<T extends FieldValues>(
+  setError: UseFormSetError<T>,
+  fieldErrors: ValidationFieldErrors,
+) {
+  Object.entries(fieldErrors).forEach(([field, message]) => {
+    setError(field as Path<T>, { message })
+  })
+}

--- a/src/hooks/useInitAuth.ts
+++ b/src/hooks/useInitAuth.ts
@@ -1,26 +1,20 @@
 import { useEffect } from 'react'
 import { useAuthStore } from '@/stores/authStore'
 import { apiClient } from '@/api/client'
-import type { ApiResponse, RefreshResponse } from '@/types/api'
-import type { User } from '@/types/auth'
+import type { ApiResponse } from '@/types/api'
+import type { AuthSessionResponse } from '@/types/auth'
 
 let hasInitializedAuth = false
 
 async function initAuth() {
-  const { setAuth, setAccessToken, setLoading, clearAuth } = useAuthStore.getState()
+  const { setAuth, setLoading, clearAuth } = useAuthStore.getState()
 
   try {
-    // HttpOnly 쿠키의 refresh 토큰으로 새 accessToken 발급
-    const refreshRes = await apiClient.post<ApiResponse<RefreshResponse>>('/auth/refresh')
-    const token = refreshRes.data.data!.accessToken
+    // HttpOnly 쿠키의 refresh 토큰으로 세션을 복구
+    const refreshRes = await apiClient.post<ApiResponse<AuthSessionResponse>>('/auth/refresh')
+    const session = refreshRes.data.data!
 
-    setAccessToken(token)
-
-    // accessToken으로 유저 정보 조회
-    const userRes = await apiClient.get<ApiResponse<User>>('/users/me')
-    const user = userRes.data.data!
-
-    setAuth(token, user)
+    setAuth(session.accessToken, session.user)
   } catch {
     clearAuth()
   } finally {

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,3 +1,149 @@
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { Link, useNavigate } from 'react-router-dom'
+import axios from 'axios'
+import { useAuthStore } from '@/stores/authStore'
+import { postLogin } from '@/api/auth'
+import { RoutinelyWordmark } from '@/components/common/Logo'
+import AuthShell from '@/components/auth/AuthShell'
+import PasswordField from '@/components/auth/PasswordField'
+import type { ApiResponse } from '@/types/api'
+import styles from '@/components/auth/authForm.module.css'
+
+const schema = z.object({
+  email: z.string().min(1, '이메일을 입력해주세요.').email('올바른 이메일 형식이어야 합니다.'),
+  password: z.string().min(1, '비밀번호를 입력해주세요.'),
+})
+
+type FormValues = z.infer<typeof schema>
+type ValidationFieldErrors = Record<string, string>
+
+const DEFAULT_SERVER_ERROR_MESSAGE =
+  '일시적인 서버 문제로 요청을 처리할 수 없습니다. 잠시 후 다시 시도해주세요.'
+
 export default function LoginPage() {
-  return <div className="p-4 text-text-primary">로그인</div>
+  const navigate = useNavigate()
+  const setAuth = useAuthStore((s) => s.setAuth)
+
+  const {
+    register,
+    handleSubmit,
+    setError,
+    formState: { errors, isSubmitting },
+  } = useForm<FormValues>({ resolver: zodResolver(schema) })
+
+  const onSubmit = async (data: FormValues) => {
+    try {
+      const result = await postLogin(data)
+      setAuth(result.accessToken, result.user)
+      navigate('/', { replace: true })
+    } catch (err) {
+      if (!axios.isAxiosError<ApiResponse<ValidationFieldErrors>>(err)) {
+        const message = err instanceof Error ? err.message : DEFAULT_SERVER_ERROR_MESSAGE
+        setError('root', { message })
+        return
+      }
+
+      const errorCode = err.response?.data?.errorCode
+      const message = err.response?.data?.message
+
+      if (errorCode === 'VALIDATION_FAILED') {
+        const fieldErrors = err.response?.data?.data ?? {}
+        Object.entries(fieldErrors).forEach(([field, fieldMessage]) => {
+          setError(field as keyof FormValues, { message: fieldMessage })
+        })
+
+        if (Object.keys(fieldErrors).length === 0) {
+          setError('root', { message: message ?? '입력값을 다시 확인해주세요.' })
+        }
+        return
+      }
+
+      if (errorCode === 'INVALID_CREDENTIALS') {
+        setError('root', {
+          message: message ?? '이메일 또는 비밀번호가 올바르지 않습니다.',
+        })
+        return
+      }
+
+      if (message) {
+        setError('root', { message })
+        return
+      }
+
+      setError('root', { message: DEFAULT_SERVER_ERROR_MESSAGE })
+    }
+  }
+
+  return (
+    <AuthShell variant="split">
+      <RoutinelyWordmark size={36} />
+
+      <div style={{ marginTop: 60 }}>
+        <div
+          style={{
+            fontSize: 11,
+            letterSpacing: '.14em',
+            textTransform: 'uppercase',
+            fontWeight: 700,
+            color: 'var(--coral-600)',
+          }}
+        >
+          WELCOME BACK
+        </div>
+        <h1
+          style={{
+            fontSize: 52,
+            lineHeight: 1.05,
+            letterSpacing: '-0.035em',
+            fontWeight: 700,
+            marginTop: 12,
+          }}
+        >
+          오늘도
+          <br />
+          시작해볼까요?
+        </h1>
+        <p style={{ color: 'var(--text-muted)', marginTop: 14, fontSize: 15 }}>
+          21일째 함께하는 친구들이 기다리고 있어요.
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit(onSubmit)} className={styles.form} style={{ marginTop: 36 }}>
+        <div className={styles.field}>
+          <input
+            type="email"
+            autoComplete="email"
+            aria-label="이메일"
+            placeholder="이메일"
+            {...register('email')}
+            className={`${styles.input} ${errors.email ? styles.inputError : ''}`}
+          />
+          {errors.email && <span className={styles.fieldError}>{errors.email.message}</span>}
+        </div>
+
+        <PasswordField
+          autoComplete="current-password"
+          aria-label="비밀번호"
+          placeholder="비밀번호 (영문만)"
+          errorMessage={errors.password?.message}
+          {...register('password')}
+        />
+
+        {errors.root && <div className={styles.rootError}>{errors.root.message}</div>}
+
+        <button type="submit" disabled={isSubmitting} className={styles.submitBtn}>
+          {isSubmitting ? '로그인 중...' : '로그인 →'}
+        </button>
+
+        <p className={styles.footer}>
+          처음이신가요?{' '}
+          <Link to="/signup" className={styles.footerLink}>
+            회원가입
+          </Link>
+        </p>
+      </form>
+    </AuthShell>
+  )
 }

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -2,13 +2,16 @@ import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import { Link, useNavigate } from 'react-router-dom'
-import axios from 'axios'
 import { useAuthStore } from '@/stores/authStore'
 import { postLogin } from '@/api/auth'
 import { RoutinelyWordmark } from '@/components/common/Logo'
 import AuthShell from '@/components/auth/AuthShell'
 import PasswordField from '@/components/auth/PasswordField'
-import type { ApiResponse } from '@/types/api'
+import {
+  applyValidationFieldErrors,
+  getApiErrorPayload,
+  type ValidationFieldErrors,
+} from '@/components/auth/authFormErrors'
 import styles from '@/components/auth/authForm.module.css'
 
 const schema = z.object({
@@ -17,7 +20,6 @@ const schema = z.object({
 })
 
 type FormValues = z.infer<typeof schema>
-type ValidationFieldErrors = Record<string, string>
 
 const DEFAULT_SERVER_ERROR_MESSAGE =
   '일시적인 서버 문제로 요청을 처리할 수 없습니다. 잠시 후 다시 시도해주세요.'
@@ -39,20 +41,19 @@ export default function LoginPage() {
       setAuth(result.accessToken, result.user)
       navigate('/', { replace: true })
     } catch (err) {
-      if (!axios.isAxiosError<ApiResponse<ValidationFieldErrors>>(err)) {
+      const apiError = getApiErrorPayload<ValidationFieldErrors>(err)
+
+      if (!apiError) {
         const message = err instanceof Error ? err.message : DEFAULT_SERVER_ERROR_MESSAGE
         setError('root', { message })
         return
       }
 
-      const errorCode = err.response?.data?.errorCode
-      const message = err.response?.data?.message
+      const { errorCode, message } = apiError
 
       if (errorCode === 'VALIDATION_FAILED') {
-        const fieldErrors = err.response?.data?.data ?? {}
-        Object.entries(fieldErrors).forEach(([field, fieldMessage]) => {
-          setError(field as keyof FormValues, { message: fieldMessage })
-        })
+        const fieldErrors = apiError.data ?? {}
+        applyValidationFieldErrors(setError, fieldErrors)
 
         if (Object.keys(fieldErrors).length === 0) {
           setError('root', { message: message ?? '입력값을 다시 확인해주세요.' })

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -6,6 +6,7 @@ import { useAuthStore } from '@/stores/authStore'
 import { postLogin } from '@/api/auth'
 import { RoutinelyWordmark } from '@/components/common/Logo'
 import AuthShell from '@/components/auth/AuthShell'
+import AuthIntro from '@/components/auth/AuthIntro'
 import PasswordField from '@/components/auth/PasswordField'
 import {
   applyValidationFieldErrors,
@@ -81,35 +82,22 @@ export default function LoginPage() {
     <AuthShell variant="split">
       <RoutinelyWordmark size={36} />
 
-      <div style={{ marginTop: 60 }}>
-        <div
-          style={{
-            fontSize: 11,
-            letterSpacing: '.14em',
-            textTransform: 'uppercase',
-            fontWeight: 700,
-            color: 'var(--coral-600)',
-          }}
-        >
-          WELCOME BACK
-        </div>
-        <h1
-          style={{
-            fontSize: 52,
-            lineHeight: 1.05,
-            letterSpacing: '-0.035em',
-            fontWeight: 700,
-            marginTop: 12,
-          }}
-        >
-          오늘도
-          <br />
-          시작해볼까요?
-        </h1>
-        <p style={{ color: 'var(--text-muted)', marginTop: 14, fontSize: 15 }}>
-          21일째 함께하는 친구들이 기다리고 있어요.
-        </p>
-      </div>
+      <AuthIntro
+        eyebrow="WELCOME BACK"
+        title={
+          <>
+            오늘도
+            <br />
+            시작해볼까요?
+          </>
+        }
+        description="21일째 함께하는 친구들이 기다리고 있어요."
+        containerMarginTop={60}
+        titleMarginTop={12}
+        titleFontSize={52}
+        titleLetterSpacing="-0.035em"
+        descriptionMarginTop={14}
+      />
 
       <form onSubmit={handleSubmit(onSubmit)} className={styles.form} style={{ marginTop: 36 }}>
         <div className={styles.field}>

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -1,3 +1,145 @@
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { Link, useNavigate } from 'react-router-dom'
+import axios from 'axios'
+import { postSignup } from '@/api/auth'
+import { RoutinelyWordmark } from '@/components/common/Logo'
+import AuthShell from '@/components/auth/AuthShell'
+import PasswordField from '@/components/auth/PasswordField'
+import type { ApiResponse } from '@/types/api'
+import styles from '@/components/auth/authForm.module.css'
+
+const schema = z.object({
+  email: z.string().min(1, '이메일을 입력해주세요.').email('올바른 이메일 형식이어야 합니다.'),
+  nickname: z
+    .string()
+    .min(1, '닉네임을 입력해주세요.')
+    .min(2, '닉네임은 2자 이상이어야 합니다.')
+    .max(20, '닉네임은 20자 이하여야 합니다.'),
+  password: z
+    .string()
+    .min(1, '비밀번호를 입력해주세요.')
+    .min(8, '비밀번호는 8자 이상이어야 합니다.'),
+})
+
+type FormValues = z.infer<typeof schema>
+
+type ValidationFieldErrors = Record<string, string>
+
 export default function SignupPage() {
-  return <div className="p-4 text-text-primary">회원가입</div>
+  const navigate = useNavigate()
+
+  const {
+    register,
+    handleSubmit,
+    setError,
+    formState: { errors, isSubmitting },
+  } = useForm<FormValues>({ resolver: zodResolver(schema) })
+
+  const onSubmit = async (data: FormValues) => {
+    try {
+      await postSignup(data)
+      navigate('/login')
+    } catch (err) {
+      if (!axios.isAxiosError<ApiResponse<ValidationFieldErrors>>(err)) return
+
+      const errorCode = err.response?.data?.errorCode
+      const message = err.response?.data?.message ?? '회원가입에 실패했습니다.'
+
+      if (errorCode === 'VALIDATION_FAILED') {
+        const fieldErrors = err.response?.data?.data ?? {}
+        Object.entries(fieldErrors).forEach(([field, msg]) => {
+          setError(field as keyof FormValues, { message: msg })
+        })
+        return
+      }
+
+      if (errorCode === 'EMAIL_ALREADY_EXISTS') {
+        setError('email', { message })
+        return
+      }
+
+      if (errorCode === 'NICKNAME_ALREADY_EXISTS') {
+        setError('nickname', { message })
+        return
+      }
+
+      setError('root', { message })
+    }
+  }
+
+  return (
+    <AuthShell variant="centered">
+      <RoutinelyWordmark size={36} />
+
+      <div style={{ marginTop: 36 }}>
+        <h1
+          style={{
+            fontSize: 44,
+            lineHeight: 1.05,
+            letterSpacing: '-0.03em',
+            fontWeight: 700,
+            marginTop: 24,
+          }}
+        >
+          시작해볼까요?
+        </h1>
+        <p style={{ color: 'var(--text-muted)', fontSize: 15, marginTop: 8 }}>
+          Routinely에서 꾸준한 루틴을 만들어보세요.
+        </p>
+      </div>
+
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        className={styles.form}
+        style={{ marginTop: 28, gap: 14 }}
+      >
+        <div className={styles.field}>
+          <input
+            type="email"
+            autoComplete="email"
+            aria-label="이메일"
+            placeholder="이메일"
+            {...register('email')}
+            className={`${styles.input} ${errors.email ? styles.inputError : ''}`}
+          />
+          {errors.email && <span className={styles.fieldError}>{errors.email.message}</span>}
+        </div>
+
+        <div className={styles.field}>
+          <input
+            type="text"
+            autoComplete="nickname"
+            aria-label="닉네임"
+            placeholder="닉네임 (2~20자)"
+            {...register('nickname')}
+            className={`${styles.input} ${errors.nickname ? styles.inputError : ''}`}
+          />
+          {errors.nickname && <span className={styles.fieldError}>{errors.nickname.message}</span>}
+        </div>
+
+        <PasswordField
+          autoComplete="new-password"
+          aria-label="비밀번호"
+          placeholder="비밀번호 (영문 8자 이상)"
+          errorMessage={errors.password?.message}
+          {...register('password')}
+        />
+
+        {errors.root && <div className={styles.rootError}>{errors.root.message}</div>}
+
+        <button type="submit" disabled={isSubmitting} className={styles.submitBtn}>
+          {isSubmitting ? '가입 중...' : '가입하기 →'}
+        </button>
+
+        <p className={styles.footer}>
+          이미 계정이 있나요?{' '}
+          <Link to="/login" className={styles.footerLink}>
+            로그인
+          </Link>
+        </p>
+      </form>
+    </AuthShell>
+  )
 }

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -5,6 +5,7 @@ import { Link, useNavigate } from 'react-router-dom'
 import { postSignup } from '@/api/auth'
 import { RoutinelyWordmark } from '@/components/common/Logo'
 import AuthShell from '@/components/auth/AuthShell'
+import AuthIntro from '@/components/auth/AuthIntro'
 import PasswordField from '@/components/auth/PasswordField'
 import {
   applyValidationFieldErrors,
@@ -77,22 +78,15 @@ export default function SignupPage() {
     <AuthShell variant="centered">
       <RoutinelyWordmark size={36} />
 
-      <div style={{ marginTop: 36 }}>
-        <h1
-          style={{
-            fontSize: 44,
-            lineHeight: 1.05,
-            letterSpacing: '-0.03em',
-            fontWeight: 700,
-            marginTop: 24,
-          }}
-        >
-          시작해볼까요?
-        </h1>
-        <p style={{ color: 'var(--text-muted)', fontSize: 15, marginTop: 8 }}>
-          Routinely에서 꾸준한 루틴을 만들어보세요.
-        </p>
-      </div>
+      <AuthIntro
+        title="시작해볼까요?"
+        description="Routinely에서 꾸준한 루틴을 만들어보세요."
+        containerMarginTop={36}
+        titleMarginTop={24}
+        titleFontSize={44}
+        titleLetterSpacing="-0.03em"
+        descriptionMarginTop={8}
+      />
 
       <form
         onSubmit={handleSubmit(onSubmit)}

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -2,12 +2,15 @@ import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import { Link, useNavigate } from 'react-router-dom'
-import axios from 'axios'
 import { postSignup } from '@/api/auth'
 import { RoutinelyWordmark } from '@/components/common/Logo'
 import AuthShell from '@/components/auth/AuthShell'
 import PasswordField from '@/components/auth/PasswordField'
-import type { ApiResponse } from '@/types/api'
+import {
+  applyValidationFieldErrors,
+  getApiErrorPayload,
+  type ValidationFieldErrors,
+} from '@/components/auth/authFormErrors'
 import styles from '@/components/auth/authForm.module.css'
 
 const schema = z.object({
@@ -25,8 +28,6 @@ const schema = z.object({
 
 type FormValues = z.infer<typeof schema>
 
-type ValidationFieldErrors = Record<string, string>
-
 export default function SignupPage() {
   const navigate = useNavigate()
 
@@ -42,16 +43,19 @@ export default function SignupPage() {
       await postSignup(data)
       navigate('/login')
     } catch (err) {
-      if (!axios.isAxiosError<ApiResponse<ValidationFieldErrors>>(err)) return
+      const apiError = getApiErrorPayload<ValidationFieldErrors>(err)
 
-      const errorCode = err.response?.data?.errorCode
-      const message = err.response?.data?.message ?? '회원가입에 실패했습니다.'
+      if (!apiError) {
+        setError('root', { message: '회원가입에 실패했습니다.' })
+        return
+      }
+
+      const { errorCode } = apiError
+      const message = apiError.message ?? '회원가입에 실패했습니다.'
 
       if (errorCode === 'VALIDATION_FAILED') {
-        const fieldErrors = err.response?.data?.data ?? {}
-        Object.entries(fieldErrors).forEach(([field, msg]) => {
-          setError(field as keyof FormValues, { message: msg })
-        })
+        const fieldErrors = apiError.data ?? {}
+        applyValidationFieldErrors(setError, fieldErrors)
         return
       }
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -12,7 +12,3 @@ export interface PageResponse<T> {
   hasNext: boolean
   totalElements?: number
 }
-
-export interface RefreshResponse {
-  accessToken: string
-}

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,6 +1,30 @@
 export interface User {
-  id: number
+  userId: number
   email: string
   nickname: string
   profileImageUrl: string | null
 }
+
+export interface AuthSessionResponse {
+  accessToken: string
+  user: User
+}
+
+export interface SignupRequest {
+  email: string
+  nickname: string
+  password: string
+}
+
+export interface LoginRequest {
+  email: string
+  password: string
+}
+
+export interface SignupResponse {
+  userId: number
+  email: string
+  nickname: string
+}
+
+export type LoginResponse = AuthSessionResponse


### PR DESCRIPTION
## ✅ 무엇을 변경했나요?
- 인증 타입(`LoginRequest`, `SignupRequest`, `AuthSessionResponse` 등) 및 API 함수(`postLogin`, `postSignup`) 추가
- 인증 공통 컴포넌트 구현 — `AuthShell`(레이아웃), `PasswordField`(비밀번호 토글), `AuthIntro`(인트로 텍스트)
- 로그인 페이지 구현 — 좌우 split 레이아웃, Zod 유효성 검사, 에러 코드 분기 처리
- 회원가입 페이지 구현 — centered 레이아웃, Zod 유효성 검사, 에러 코드 분기 처리
- API 에러 처리 유틸 분리 — `getApiErrorPayload`, `applyValidationFieldErrors`
- 토큰 갱신 인터셉터 개선

## 🎯 왜 변경했나요? (문제/배경)
- 이 PR이 해결하는 문제: 사용자 진입점인 로그인·회원가입 화면이 없어 인증 흐름 전체가 동작하지 않았음
- 관련 맥락/배경: 서버의 `VALIDATION_FAILED`, `INVALID_CREDENTIALS`, `EMAIL_ALREADY_EXISTS`, `NICKNAME_ALREADY_EXISTS` 에러 코드에 맞춰 필드 단위 에러 표시까지 처리함

## 🔗 관련 이슈
- Closes #11

## 🧪 테스트/검증 방법
- [x] 로컬 빌드/실행 확인
- [x] 핵심 시나리오 수동 테스트

### 검증 시나리오
1. 회원가입 — 정상 입력 → `/login`으로 리다이렉트
2. 회원가입 — 이미 사용 중인 이메일/닉네임 → 해당 필드에 에러 메시지 표시
3. 로그인 — 정상 입력 → 토큰 저장 후 `/`으로 리다이렉트
4. 로그인 — 잘못된 이메일·비밀번호 → root 에러 메시지 표시
5. 각 폼 — 빈 입력 제출 → Zod 클라이언트 유효성 에러 표시

## ✅ 체크리스트
- [x] 코드가 컴파일/빌드 됩니다
- [x] 불필요한 디버그 코드/로그를 제거했습니다
- [x] 에러 케이스를 고려했습니다
- [x] (Front-end) UI/상태 변경이 의도대로 동작합니다