### PR TITLE
[feat] #12 헤더 프로필 드롭다운 및 로그아웃 처리 구현

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -19,3 +19,7 @@ export async function postLogin(data: LoginRequest): Promise<LoginResponse> {
   const res = await apiClient.post<ApiResponse<LoginResponse>>('/auth/login', data)
   return unwrapApiResponse(res.data, '로그인에 실패했습니다.')
 }
+
+export async function postLogout(): Promise<void> {
+  await apiClient.post<ApiResponse<null>>('/auth/logout')
+}

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -3,6 +3,7 @@ import axios, { type InternalAxiosRequestConfig } from 'axios'
 import { useAuthStore } from '@/stores/authStore'
 import type { ApiResponse } from '@/types/api'
 import type { AuthSessionResponse } from '@/types/auth'
+import { clearAuthSessionAndRedirect } from '@/utils/authSession'
 
 const apiBaseUrl = import.meta.env.VITE_API_BASE_URL
 
@@ -75,8 +76,7 @@ apiClient.interceptors.response.use(
 
     // 재시도한 요청도 401이면 바로 로그아웃
     if (originalRequest._retry) {
-      useAuthStore.getState().clearAuth()
-      window.location.href = '/login'
+      clearAuthSessionAndRedirect()
       return Promise.reject(error)
     }
 
@@ -101,7 +101,6 @@ apiClient.interceptors.response.use(
       return retryRequest(originalRequest, session.accessToken)
     } catch (refreshError) {
       processQueue(refreshError)
-      useAuthStore.getState().clearAuth()
 
       try {
         await apiClient.post('/auth/logout')
@@ -109,7 +108,7 @@ apiClient.interceptors.response.use(
         // best-effort: 로그아웃 API 실패해도 클라이언트는 로그아웃 처리
       }
 
-      window.location.href = '/login'
+      clearAuthSessionAndRedirect()
       return Promise.reject(refreshError)
     } finally {
       isRefreshing = false

--- a/src/components/layout/Header.module.css
+++ b/src/components/layout/Header.module.css
@@ -4,7 +4,7 @@
   align-items: center;
   height: 56px;
   flex-shrink: 0;
-  column-gap: 18px;
+  column-gap: 24px;
   padding: 0 24px;
   border-bottom: 1px solid var(--border);
   background: var(--surface);
@@ -20,7 +20,7 @@
 .nav {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 12px;
   min-width: 0;
   overflow-x: auto;
   overflow-y: hidden;
@@ -42,7 +42,9 @@
   border-radius: 10px;
   text-decoration: none;
   white-space: nowrap;
-  transition: color 200ms ease, background-color 200ms ease;
+  transition:
+    color 200ms ease,
+    background-color 200ms ease;
 }
 
 .navItemActive {
@@ -79,7 +81,9 @@
   opacity: 0;
   transform: scaleX(0);
   transform-origin: center;
-  transition: transform 200ms ease, opacity 200ms ease;
+  transition:
+    transform 200ms ease,
+    opacity 200ms ease;
 }
 
 .navIndicatorActive {
@@ -94,6 +98,10 @@
   flex-shrink: 0;
 }
 
+.profileMenuWrapper {
+  position: relative;
+}
+
 .iconLink {
   position: relative;
   display: inline-flex;
@@ -104,7 +112,9 @@
   border-radius: 999px;
   color: var(--text-muted);
   text-decoration: none;
-  transition: color 200ms ease, background-color 200ms ease;
+  transition:
+    color 200ms ease,
+    background-color 200ms ease;
 }
 
 .iconLink:hover {
@@ -133,7 +143,32 @@
   box-shadow: 0 0 0 1px var(--surface);
 }
 
-.profile {
+.profileTrigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+  transition:
+    background-color 200ms ease,
+    border-color 200ms ease,
+    color 200ms ease;
+}
+
+.profileTrigger:hover {
+  background: var(--surface-2);
+}
+
+.profileTriggerOpen {
+  border-color: var(--border);
+  background: var(--surface-2);
+}
+
+.profileAvatar {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -146,7 +181,67 @@
   font-size: 13px;
   font-weight: 700;
   font-family: 'Pretendard', sans-serif;
+}
+
+.profileMenuChevron {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  color: var(--text-muted);
+}
+
+.profileMenu {
+  position: absolute;
+  top: calc(100% + 10px);
+  right: 0;
+  z-index: 20;
+  display: grid;
+  min-width: 168px;
+  padding: 8px;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background: var(--surface);
+  box-shadow: var(--sh-2);
+}
+
+.profileMenuItem {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  min-height: 42px;
+  padding: 0 12px;
+  border: none;
+  border-radius: 12px;
+  background: transparent;
+  color: var(--text);
+  font-size: 14px;
+  font-weight: 600;
   text-decoration: none;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    background-color 200ms ease,
+    color 200ms ease;
+}
+
+.profileMenuItem:hover {
+  background: var(--surface-2);
+}
+
+.profileMenuItemDanger {
+  color: var(--danger);
+}
+
+.profileMenuItemDanger:hover {
+  background: color-mix(in srgb, var(--danger) 8%, var(--surface));
+}
+
+.profileMenuItem:disabled {
+  opacity: 0.72;
+  cursor: wait;
 }
 
 @media (max-width: 720px) {

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,7 +1,9 @@
-import type { ReactNode } from 'react'
+import { useEffect, useRef, useState, type ReactNode } from 'react'
 import { Link, useLocation } from 'react-router-dom'
+import { postLogout } from '@/api/auth'
 import { useAuthStore } from '@/stores/authStore'
 import { RoutinelyWordmark } from '@/components/common/Logo'
+import { clearAuthSessionAndRedirect } from '@/utils/authSession'
 import { cn } from '@/utils/cn'
 import styles from './Header.module.css'
 
@@ -45,6 +47,20 @@ const ICON_PATHS: Record<string, ReactNode> = {
       <path d="M10 21a2 2 0 004 0" />
     </>
   ),
+  chevronDown: <path d="M6 9l6 6 6-6" />,
+  user: (
+    <>
+      <path d="M12 13a4 4 0 100-8 4 4 0 000 8z" />
+      <path d="M5 21a7 7 0 0114 0" />
+    </>
+  ),
+  logout: (
+    <>
+      <path d="M9 21H5a2 2 0 01-2-2V5a2 2 0 012-2h4" />
+      <path d="M16 17l5-5-5-5" />
+      <path d="M21 12H9" />
+    </>
+  ),
 }
 
 function NavIcon({ name }: { name: string }) {
@@ -83,9 +99,30 @@ function BellIcon() {
   )
 }
 
+function ProfileMenuIcon({ name }: { name: 'chevronDown' | 'user' | 'logout' }) {
+  return (
+    <svg
+      width={16}
+      height={16}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.8}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      {ICON_PATHS[name]}
+    </svg>
+  )
+}
+
 export default function Header() {
   const { pathname } = useLocation()
   const { user } = useAuthStore()
+  const [isProfileMenuOpen, setIsProfileMenuOpen] = useState(false)
+  const [isLoggingOut, setIsLoggingOut] = useState(false)
+  const profileMenuRef = useRef<HTMLDivElement>(null)
   const notificationCount = 0
 
   const isActive = (path: string): boolean => {
@@ -95,10 +132,62 @@ export default function Header() {
 
   const initial = user?.nickname?.[0] ?? '?'
 
+  useEffect(() => {
+    if (!isProfileMenuOpen) {
+      return
+    }
+
+    const handlePointerDown = (event: MouseEvent) => {
+      if (!profileMenuRef.current?.contains(event.target as Node)) {
+        setIsProfileMenuOpen(false)
+      }
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsProfileMenuOpen(false)
+      }
+    }
+
+    document.addEventListener('mousedown', handlePointerDown)
+    document.addEventListener('keydown', handleKeyDown)
+
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [isProfileMenuOpen])
+
+  const handleProfileMenuToggle = () => {
+    setIsProfileMenuOpen((prev) => !prev)
+  }
+
+  const handleMenuClose = () => {
+    setIsProfileMenuOpen(false)
+  }
+
+  const handleLogout = async () => {
+    if (isLoggingOut) {
+      return
+    }
+
+    setIsLoggingOut(true)
+
+    try {
+      await postLogout()
+    } catch {
+      // best-effort: 서버 로그아웃 실패와 무관하게 클라이언트 세션은 종료한다.
+    } finally {
+      handleMenuClose()
+      clearAuthSessionAndRedirect()
+      setIsLoggingOut(false)
+    }
+  }
+
   return (
     <header className={styles.appHeader}>
       <Link to="/" aria-label="홈으로" className={styles.brand}>
-        <RoutinelyWordmark size={24} />
+        <RoutinelyWordmark size={26} />
       </Link>
 
       <nav className={styles.nav} aria-label="주 메뉴">
@@ -123,14 +212,49 @@ export default function Header() {
       <div className={styles.actions}>
         <Link to="/notifications" aria-label="알림" className={styles.iconLink}>
           <BellIcon />
-          {notificationCount > 0 && (
-            <span className={styles.badge}>{notificationCount}</span>
-          )}
+          {notificationCount > 0 && <span className={styles.badge}>{notificationCount}</span>}
         </Link>
 
-        <Link to="/profile" aria-label="프로필" className={styles.profile}>
-          {initial}
-        </Link>
+        <div className={styles.profileMenuWrapper} ref={profileMenuRef}>
+          <button
+            type="button"
+            aria-label="프로필 메뉴"
+            aria-expanded={isProfileMenuOpen}
+            aria-haspopup="menu"
+            className={cn(styles.profileTrigger, isProfileMenuOpen && styles.profileTriggerOpen)}
+            onClick={handleProfileMenuToggle}
+          >
+            <span className={styles.profileAvatar}>{initial}</span>
+            <span className={styles.profileMenuChevron}>
+              <ProfileMenuIcon name="chevronDown" />
+            </span>
+          </button>
+
+          {isProfileMenuOpen && (
+            <div className={styles.profileMenu} role="menu" aria-label="프로필 메뉴">
+              <Link
+                to="/profile"
+                role="menuitem"
+                className={styles.profileMenuItem}
+                onClick={handleMenuClose}
+              >
+                <ProfileMenuIcon name="user" />
+                <span>마이페이지</span>
+              </Link>
+
+              <button
+                type="button"
+                role="menuitem"
+                className={cn(styles.profileMenuItem, styles.profileMenuItemDanger)}
+                onClick={handleLogout}
+                disabled={isLoggingOut}
+              >
+                <ProfileMenuIcon name="logout" />
+                <span>{isLoggingOut ? '로그아웃 중...' : '로그아웃'}</span>
+              </button>
+            </div>
+          )}
+        </div>
       </div>
     </header>
   )

--- a/src/utils/authSession.ts
+++ b/src/utils/authSession.ts
@@ -1,0 +1,14 @@
+import { useAuthStore } from '@/stores/authStore'
+
+export const clearAuthSession = () => {
+  useAuthStore.getState().clearAuth()
+}
+
+export const redirectToLogin = () => {
+  window.location.href = '/login'
+}
+
+export const clearAuthSessionAndRedirect = () => {
+  clearAuthSession()
+  redirectToLogin()
+}


### PR DESCRIPTION
## ✅ 무엇을 변경했나요?
- 헤더 우측 상단 프로필 아바타 클릭 시 드롭다운 메뉴(마이페이지, 로그아웃)가 표시되도록 구현
- 로그아웃 버튼 클릭 시 `POST /api/v1/auth/logout` 호출 후 성공/실패 여부와 관계없이 authStore 초기화 및 `/login` 이동
- 인터셉터 내 인라인 세션 초기화 코드를 `clearAuthSessionAndRedirect()` 유틸로 추출

## 🎯 왜 변경했나요? (문제/배경)
- 이 PR이 해결하는 문제: 로그아웃 UI가 없어 사용자가 직접 세션을 종료할 수 없었음
- 관련 맥락/배경: Refresh Token은 HttpOnly Cookie이므로 서버 응답의 Set-Cookie로 자동 삭제됨. API 호출 실패 시에도 클라이언트 상태를 반드시 초기화해야 함

## 🔗 관련 이슈
- Closes #12

## 🧪 테스트/검증 방법
- [x] 로컬 빌드/실행 확인
- [x] 핵심 시나리오 수동 테스트

### 검증 시나리오
1. 헤더 프로필 아바타 클릭 → 드롭다운(마이페이지, 로그아웃) 표시 확인
2. 드롭다운 외부 클릭 또는 ESC 키 → 드롭다운 닫힘 확인
3. 로그아웃 클릭 → API 호출 → authStore 초기화 → `/login` 이동 확인
4. 마이페이지 클릭 → `/profile` 이동 확인

## 📸 스크린샷/로그 (선택)
- UI 변경이 있으면 스크린샷 첨부

## ✅ 체크리스트
- [x] 코드가 컴파일/빌드 됩니다
- [x] 불필요한 디버그 코드/로그를 제거했습니다
- [x] 에러 케이스를 고려했습니다
- [ ] (필요 시) 문서/주석을 업데이트했습니다
- [x] (Front-end) UI/상태 변경이 의도대로 동작합니다

## 📝 기타 공유사항 (선택)
- 후속 작업(To-do): 마이페이지 화면 구현 (#13)