### PR TITLE
[feat] #39 404 Not Found 페이지 구현

### DIFF
--- a/src/pages/NotFoundPage.module.css
+++ b/src/pages/NotFoundPage.module.css
@@ -1,0 +1,280 @@
+.page {
+  position: relative;
+  min-height: 100%;
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+  padding: 40px 60px;
+  background: var(--bg);
+}
+
+.backdrop {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  user-select: none;
+  z-index: 0;
+  font-family: 'Geist', sans-serif;
+  font-weight: 800;
+  font-size: clamp(280px, 38vw, 520px);
+  letter-spacing: -0.06em;
+  line-height: 0.85;
+  color: transparent;
+  -webkit-text-stroke: 2px var(--coral-100);
+}
+
+.content {
+  position: relative;
+  z-index: 2;
+  display: grid;
+  grid-template-columns: 1.15fr 1fr;
+  align-items: center;
+  gap: 60px;
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+/* ── Left: copy ─────────────────────────────────── */
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: var(--coral-100);
+  color: var(--coral-700);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+}
+
+.badgeDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--coral-500);
+  flex-shrink: 0;
+}
+
+.heading {
+  font-size: clamp(48px, 7vw, 88px);
+  font-weight: 800;
+  letter-spacing: -0.045em;
+  line-height: 0.95;
+  margin-top: 20px;
+  white-space: nowrap;
+}
+
+.headingAccent {
+  color: var(--coral-500);
+}
+
+.sub {
+  font-size: 18px;
+  color: var(--text-muted);
+  max-width: 520px;
+  line-height: 1.55;
+  margin-top: 24px;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 32px;
+}
+
+.btnPrimary {
+  display: inline-flex;
+  align-items: center;
+  height: 48px;
+  padding: 0 24px;
+  border-radius: 12px;
+  background: var(--coral-500);
+  color: white;
+  font-size: 15px;
+  font-weight: 700;
+  text-decoration: none;
+  transition: background-color 200ms ease;
+}
+
+.btnPrimary:hover {
+  background: var(--coral-600);
+}
+
+.btnGhost {
+  display: inline-flex;
+  align-items: center;
+  height: 48px;
+  padding: 0 24px;
+  border-radius: 12px;
+  background: transparent;
+  color: var(--text);
+  font-size: 15px;
+  font-weight: 700;
+  border: 1.5px solid var(--border-strong);
+  cursor: pointer;
+  transition: background-color 200ms ease;
+}
+
+.btnGhost:hover {
+  background: var(--surface-2);
+}
+
+
+/* ── Right: calendar card ───────────────────────── */
+
+.visual {
+  display: flex;
+  justify-content: center;
+}
+
+.card {
+  padding: 28px;
+  border-radius: 20px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  box-shadow: var(--sh-3);
+  transform: rotate(-2deg);
+  max-width: 380px;
+  width: 100%;
+}
+
+.cardHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.cardEyebrow {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  color: var(--text-dim);
+}
+
+.cardTitle {
+  font-size: 22px;
+  font-weight: 700;
+  margin-top: 2px;
+}
+
+.flame {
+  font-size: 28px;
+}
+
+.calendar {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 8px;
+  margin-top: 22px;
+}
+
+.calDay {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.calDayLabel {
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--text-dim);
+}
+
+.calCell {
+  width: 100%;
+  aspect-ratio: 1;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: 'Geist', sans-serif;
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.calCellDone {
+  background: var(--coral-500);
+  color: white;
+}
+
+.calCellMiss {
+  background: transparent;
+  color: var(--coral-500);
+  border: 2px dashed var(--coral-500);
+}
+
+.calCellToday {
+  background: var(--ink-800);
+  color: white;
+}
+
+.calCellFuture {
+  background: var(--surface-2);
+  color: var(--text-dim);
+}
+
+.cardNote {
+  margin-top: 18px;
+  padding: 14px;
+  border-radius: 12px;
+  background: var(--surface-2);
+  border: 1px dashed var(--border-strong);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.cardNoteIcon {
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  background: var(--coral-100);
+  color: var(--coral-700);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 18px;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.cardNoteText {
+  flex: 1;
+  font-size: 12px;
+  color: var(--text-muted);
+  line-height: 1.45;
+}
+
+.cardNoteStrong {
+  color: var(--text);
+}
+
+/* ── Responsive ─────────────────────────────────── */
+
+@media (max-width: 900px) {
+  .page {
+    padding: 40px 24px;
+    align-items: flex-start;
+  }
+
+  .content {
+    grid-template-columns: 1fr;
+    gap: 40px;
+  }
+
+  .visual {
+    display: none;
+  }
+
+  .backdrop {
+    font-size: clamp(160px, 50vw, 280px);
+  }
+}

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -1,3 +1,98 @@
+import { Link, useNavigate } from 'react-router-dom'
+import styles from './NotFoundPage.module.css'
+
+type DayState = 'done' | 'miss' | 'today' | 'future'
+
+const WEEK_DAYS: Array<{ label: string; state: DayState }> = [
+  { label: '월', state: 'done' },
+  { label: '화', state: 'done' },
+  { label: '수', state: 'done' },
+  { label: '목', state: 'done' },
+  { label: '금', state: 'miss' },
+  { label: '토', state: 'today' },
+  { label: '일', state: 'future' },
+]
+
+const CELL_CLASS: Record<DayState, string> = {
+  done: styles.calCellDone,
+  miss: styles.calCellMiss,
+  today: styles.calCellToday,
+  future: styles.calCellFuture,
+}
+
+const CELL_LABEL: Record<DayState, string> = {
+  done: '✓',
+  miss: '?',
+  today: String(new Date().getDate()),
+  future: '·',
+}
+
+
 export default function NotFoundPage() {
-  return <div className="p-4 text-text-primary">404 — 페이지를 찾을 수 없습니다.</div>
+  const navigate = useNavigate()
+
+  return (
+    <div className={styles.page}>
+      <div aria-hidden className={styles.backdrop}>404</div>
+
+      <div className={styles.content}>
+        <div className={styles.copy}>
+          <span className={styles.badge}>
+            <span className={styles.badgeDot} />
+            ERROR · 404
+          </span>
+
+          <h1 className={styles.heading}>
+            잠깐 길을 <span className={styles.headingAccent}>잃었</span>네요.
+          </h1>
+
+          <p className={styles.sub}>
+            주소가 바뀌었거나, 사라진 페이지일 수 있어요.<br />
+            하지만 당신의 스트릭은 안전해요. 🔥
+          </p>
+
+          <div className={styles.actions}>
+            <Link to="/" className={styles.btnPrimary}>
+              홈으로 돌아가기
+            </Link>
+            <button type="button" className={styles.btnGhost} onClick={() => navigate(-1)}>
+              ← 이전 페이지
+            </button>
+          </div>
+
+        </div>
+
+        <div className={styles.visual}>
+          <div className={styles.card}>
+            <div className={styles.cardHeader}>
+              <div>
+                <div className={styles.cardEyebrow}>THIS WEEK</div>
+                <div className={styles.cardTitle}>이번 주 진행</div>
+              </div>
+              <span className={styles.flame}>🔥</span>
+            </div>
+
+            <div className={styles.calendar}>
+              {WEEK_DAYS.map(({ label, state }) => (
+                <div key={label} className={styles.calDay}>
+                  <div className={styles.calDayLabel}>{label}</div>
+                  <div className={`${styles.calCell} ${CELL_CLASS[state]}`}>
+                    {CELL_LABEL[state]}
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <div className={styles.cardNote}>
+              <div className={styles.cardNoteIcon}>?</div>
+              <p className={styles.cardNoteText}>
+                <strong className={styles.cardNoteStrong}>금요일</strong>처럼 잠깐 길을
+                잃을 수도 있죠.<br />다시 시작하면 돼요.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
 }


### PR DESCRIPTION
## ✅ 무엇을 변경했나요?
- placeholder였던 `NotFoundPage`를 디자인(`artboards-error.jsx`) 기반으로 구현
- 배경 대형 아웃라인 `404` 타이포, 헤드라인, 버튼, 우측 달력 카드로 구성된 풀페이지 레이아웃 적용

## 🎯 왜 변경했나요? (문제/배경)
- 이 PR이 해결하는 문제: 존재하지 않는 경로 접근 시 텍스트만 있는 빈 화면이 표시되던 문제
- 관련 맥락/배경: `design/v2/artboards-error.jsx`에 정의된 404 전용 디자인을 실제 페이지로 옮김

## 🔗 관련 이슈
- Closes #39

## 🧪 테스트/검증 방법
- [x] 로컬 빌드/실행 확인
- [x] 핵심 시나리오 수동 테스트

### 검증 시나리오
1. 존재하지 않는 경로(`/abc`) 접근 → 404 페이지 표시 확인
2. "홈으로 돌아가기" 클릭 → `/` 이동 확인
3. "← 이전 페이지" 클릭 → 이전 히스토리로 이동 확인
4. 900px 이하 화면 → 1컬럼, 달력 카드 숨김 확인

## 📸 스크린샷/로그 (선택)
- UI 변경이 있으면 스크린샷 첨부

## ✅ 체크리스트
- [x] 코드가 컴파일/빌드 됩니다
- [x] 불필요한 디버그 코드/로그를 제거했습니다
- [x] 에러 케이스를 고려했습니다
- [ ] (필요 시) 문서/주석을 업데이트했습니다
- [x] (Front-end) UI/상태 변경이 의도대로 동작합니다

## 📝 기타 공유사항 (선택)
- 달력 카드는 실제 데이터가 아닌 디자인 의도에 맞는 고정 일러스트로 구성
- 토요일 셀만 `new Date().getDate()`로 오늘 날짜를 동적으로 표시