### PR TITLE
[feat] #13 마이페이지 및 프로필 수정 기능 구현

### DIFF
--- a/design/v2/Routinely.html
+++ b/design/v2/Routinely.html
@@ -257,6 +257,7 @@ button { font-family: inherit; }
 <script type="text/babel" src="artboards-mobile.jsx"></script>
 <script type="text/babel" src="artboards-proto.jsx"></script>
 <script type="text/babel" src="artboards-error.jsx"></script>
+<script type="text/babel" src="artboards-mypage.jsx"></script>
 
 <script type="text/babel">
 const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
@@ -314,10 +315,12 @@ function App() {
         <DCArtboard id="chat-mobile" label="Chat · mobile" width={400} height={760}><MobileChatArtboard/></DCArtboard>
       </DCSection>
 
-      <DCSection id="stats-notif" title="07 · 통계 · 알림 · 프로필" subtitle="Heatmap, 차트, 알림 히스토리, 프로필">
+      <DCSection id="stats-notif" title="07 · 통계 · 알림 · 프로필" subtitle="Heatmap, 차트, 알림 히스토리, 마이페이지">
         <DCArtboard id="stats" label="Stats — heatmap + bars" width={1280} height={920}><StatsArtboard/></DCArtboard>
         <DCArtboard id="notifs" label="Notifications + Toast" width={900} height={820}><NotificationsArtboard/></DCArtboard>
-        <DCArtboard id="profile" label="Profile" width={1280} height={820}><ProfileArtboard/></DCArtboard>
+        <DCArtboard id="mypage" label="My Page · MVP" width={1280} height={820}><MyPageMvpArtboard/></DCArtboard>
+        <DCArtboard id="mypage-edit" label="My Page · 프로필 수정 모달" width={1280} height={820}><EditProfileModalArtboard/></DCArtboard>
+        <DCArtboard id="header-dropdown" label="Header · 프로필 드롭다운 (로그아웃)" width={1280} height={820}><HeaderDropdownOpenArtboard/></DCArtboard>
       </DCSection>
 
       <DCSection id="proto" title="08 · Interactive Prototype ▶" subtitle="로그인 → 홈 → 챌린지 → 채팅 — 클릭해서 흘러보세요">

--- a/design/v2/artboards-mypage.jsx
+++ b/design/v2/artboards-mypage.jsx
@@ -1,0 +1,202 @@
+// Routinely — My Page (DESKTOP WEB) · MVP only
+// Patterns: GitHub/Linear/Notion settings — single content column for MVP, sidebar nav for v2.
+// Edit = centered modal dialog (not bottom sheet — that's mobile).
+
+const HeaderDropdownOpenArtboard = () => (
+  <div style={{ width: '100%', height: '100%', background: 'var(--bg)', display: 'flex', flexDirection: 'column' }}>
+    <AppHeader active="profile-menu" />
+    <div style={{ flex: 1, padding: 36, color: 'var(--text-dim)', fontSize: 13 }}>
+      <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: '.1em', textTransform: 'uppercase', marginBottom: 8 }}>State</div>
+      <div style={{ fontSize: 18, color: 'var(--text)', fontWeight: 700 }}>로그아웃은 여기 드롭다운에서</div>
+      <div style={{ marginTop: 8 }}>마이페이지에는 로그아웃 버튼 없음 — 헤더 메뉴에 위치</div>
+    </div>
+  </div>
+);
+
+// ─── Page heading ──────────────────────────────────
+const PageHeading = ({ badge, badgeColor }) => (
+  <div style={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between', marginBottom: 28 }}>
+    <div>
+      <h1 style={{ fontSize: 32, fontWeight: 800, letterSpacing: '-0.025em', margin: 0 }}>마이페이지</h1>
+      <p style={{ fontSize: 13, color: 'var(--text-muted)', marginTop: 4 }}>프로필 정보를 관리하세요</p>
+    </div>
+    <span style={{ fontSize: 10, fontWeight: 800, letterSpacing: '.12em', padding: '5px 11px', borderRadius: 6, background: badgeColor, color: 'white' }}>{badge}</span>
+  </div>
+);
+
+// ─── Profile card (horizontal, web layout) ─────────
+const ProfileCardDesktop = () => (
+  <div className="r-card" style={{ padding: 32, position: 'relative', overflow: 'hidden' }}>
+    {/* warm decorative halo — quiet, behind content */}
+    <div aria-hidden style={{
+      position: 'absolute', top: -160, right: -120, width: 380, height: 380,
+      borderRadius: '50%', background: 'radial-gradient(circle, var(--coral-100), transparent 70%)',
+      pointerEvents: 'none',
+    }}/>
+
+    <div style={{ position: 'relative', display: 'flex', alignItems: 'center', gap: 28 }}>
+      {/* Avatar */}
+      <div style={{ position: 'relative', flexShrink: 0 }}>
+        <div style={{
+          width: 112, height: 112, borderRadius: '50%',
+          background: 'linear-gradient(135deg,#FF8A65,#FF5A2B)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          color: 'white', fontSize: 48, fontWeight: 700, fontFamily: 'Geist',
+          boxShadow: '0 8px 24px -10px rgba(255,90,43,.45)',
+        }}>지</div>
+      </div>
+
+      {/* Identity */}
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <h2 style={{ fontSize: 26, fontWeight: 800, letterSpacing: '-0.02em', margin: 0 }}>지수</h2>
+          <span style={{ fontSize: 12, color: 'var(--coral-700)', fontWeight: 700 }}>· 함께한 지 <span style={{ fontFamily: 'Geist' }}>178일째</span></span>
+        </div>
+        <p style={{ fontSize: 14, color: 'var(--text-muted)', margin: '6px 0 0', lineHeight: 1.5 }}>
+          꾸준히, 천천히, 함께.
+        </p>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 18, marginTop: 14, fontSize: 13, color: 'var(--text-dim)' }}>
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontFamily: 'Geist' }}>
+            <span>✉</span>ji•••@routinely.app
+          </span>
+          <span style={{ width: 3, height: 3, borderRadius: '50%', background: 'var(--text-dim)' }}/>
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+            <span>📅</span><span style={{ fontFamily: 'Geist' }}>2025.11.12 가입</span>
+          </span>
+        </div>
+      </div>
+
+      {/* Edit CTA */}
+      <button className="r-btn" style={{
+        background: 'var(--surface)', border: '1px solid var(--border-strong)',
+        color: 'var(--text)', fontWeight: 600, padding: '10px 18px', borderRadius: 10,
+        flexShrink: 0, alignSelf: 'flex-start',
+      }}>✎ 프로필 수정</button>
+    </div>
+  </div>
+);
+
+// ─── Section heading ───────────────────────────────
+const SectionHeading = ({ title, sub }) => (
+  <div style={{ marginBottom: 14 }}>
+    <h3 style={{ fontSize: 15, fontWeight: 700, margin: 0 }}>{title}</h3>
+    {sub && <p style={{ fontSize: 12, color: 'var(--text-muted)', margin: '3px 0 0' }}>{sub}</p>}
+  </div>
+);
+
+// ─── MVP: 마이페이지 메인 (single column, web) ─────
+const MyPageMvpArtboard = () => (
+  <div style={{ width: '100%', height: '100%', background: 'var(--bg)', display: 'flex', flexDirection: 'column' }}>
+    <AppHeader active="" />
+    <div style={{ flex: 1, overflow: 'auto', padding: '40px 0' }}>
+      <div style={{ maxWidth: 880, margin: '0 auto', padding: '0 32px' }}>
+        <PageHeading badge="MVP" badgeColor="var(--ink-800)"/>
+        <ProfileCardDesktop/>
+      </div>
+    </div>
+  </div>
+);
+
+// ─── MVP: 프로필 수정 모달 (centered dialog) ───────
+const EditProfileModalArtboard = () => (
+  <div style={{ width: '100%', height: '100%', position: 'relative', background: 'var(--bg)', display: 'flex', flexDirection: 'column' }}>
+    <AppHeader active="" />
+    {/* Dimmed page behind */}
+    <div style={{ flex: 1, overflow: 'hidden', padding: '40px 0', opacity: .5 }}>
+      <div style={{ maxWidth: 880, margin: '0 auto', padding: '0 32px' }}>
+        <PageHeading badge="MVP" badgeColor="var(--ink-800)"/>
+        <ProfileCardDesktop/>
+      </div>
+    </div>
+
+    {/* Backdrop */}
+    <div style={{ position: 'absolute', inset: 0, background: 'rgba(20,18,12,.45)' }}/>
+
+    {/* Centered modal */}
+    <div style={{
+      position: 'absolute', inset: 0,
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      padding: 24,
+    }}>
+      <div style={{
+        width: 520, background: 'var(--surface)',
+        borderRadius: 16, boxShadow: '0 24px 60px rgba(0,0,0,.22)',
+        overflow: 'hidden',
+      }}>
+        {/* Modal header */}
+        <div style={{
+          display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+          padding: '18px 24px', borderBottom: '1px solid var(--border)',
+        }}>
+          <h3 style={{ fontSize: 16, fontWeight: 700, margin: 0 }}>프로필 수정</h3>
+          <button style={{ background: 'transparent', border: 'none', fontSize: 18, color: 'var(--text-muted)', cursor: 'pointer', lineHeight: 1 }}>×</button>
+        </div>
+
+        {/* Body */}
+        <div style={{ padding: '24px 24px 8px' }}>
+          {/* Avatar row — horizontal, web style */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: 18, marginBottom: 24 }}>
+            <div style={{
+              width: 72, height: 72, borderRadius: '50%',
+              background: 'linear-gradient(135deg,#FF8A65,#FF5A2B)',
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              color: 'white', fontSize: 30, fontWeight: 700, fontFamily: 'Geist',
+              flexShrink: 0,
+            }}>지</div>
+            <div style={{ flex: 1 }}>
+              <div style={{ fontSize: 13, fontWeight: 700, marginBottom: 6 }}>프로필 사진</div>
+              <div style={{ display: 'flex', gap: 8 }}>
+                <button className="r-btn r-btn--sm" style={{ background: 'var(--text)', color: 'var(--surface)' }}>사진 업로드</button>
+                <button className="r-btn r-btn--sm" style={{ background: 'transparent', color: 'var(--text-muted)', border: '1px solid var(--border-strong)' }}>기본 이미지로</button>
+              </div>
+            </div>
+          </div>
+
+          {/* Nickname */}
+          <div style={{ marginBottom: 20 }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 6 }}>
+              <label style={{ fontSize: 12, fontWeight: 700, color: 'var(--text-muted)' }}>닉네임</label>
+              <span style={{ fontSize: 11, color: '#a86a00', fontWeight: 600 }}>30일에 한 번 변경 가능</span>
+            </div>
+            <input className="r-input" defaultValue="지수" style={{ width: '100%', fontWeight: 600, padding: '10px 12px' }}/>
+            <div style={{ fontSize: 11, color: 'var(--success)', fontWeight: 600, marginTop: 6 }}>✓ 사용 가능한 닉네임</div>
+          </div>
+
+          {/* Bio */}
+          <div style={{ marginBottom: 20 }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 6 }}>
+              <label style={{ fontSize: 12, fontWeight: 700, color: 'var(--text-muted)' }}>한 줄 소개</label>
+              <span style={{ fontSize: 11, color: 'var(--text-dim)', fontFamily: 'Geist' }}>13/100</span>
+            </div>
+            <textarea className="r-input" rows={2} defaultValue="꾸준히, 천천히, 함께." style={{ width: '100%', resize: 'none', fontFamily: 'inherit', padding: '10px 12px' }}/>
+          </div>
+
+          {/* Email — read only */}
+          <div style={{ marginBottom: 8 }}>
+            <label style={{ fontSize: 12, fontWeight: 700, color: 'var(--text-muted)', display: 'block', marginBottom: 6 }}>이메일</label>
+            <div style={{
+              padding: '10px 12px', borderRadius: 8,
+              background: 'var(--surface-2)', border: '1px solid var(--border)',
+              fontSize: 13, color: 'var(--text-muted)', fontFamily: 'Geist',
+              display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+            }}>
+              <span>ji•••@routinely.app</span>
+              <span style={{ fontSize: 11, color: 'var(--text-dim)' }}>변경 불가</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div style={{
+          display: 'flex', justifyContent: 'flex-end', gap: 8,
+          padding: '16px 24px', background: 'var(--surface-2)', borderTop: '1px solid var(--border)',
+        }}>
+          <button className="r-btn" style={{ background: 'transparent', color: 'var(--text-muted)', border: '1px solid var(--border-strong)' }}>취소</button>
+          <button className="r-btn r-btn--primary">저장</button>
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+Object.assign(window, { HeaderDropdownOpenArtboard, MyPageMvpArtboard, EditProfileModalArtboard });

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,14 +1,7 @@
 import { apiClient } from './client'
+import { unwrapApiResponse } from './response'
 import type { ApiResponse } from '@/types/api'
 import type { LoginRequest, LoginResponse, SignupRequest, SignupResponse } from '@/types/auth'
-
-function unwrapApiResponse<T>(response: ApiResponse<T>, fallbackMessage: string): T {
-  if (response.success && response.data) {
-    return response.data
-  }
-
-  throw new Error(response.message || fallbackMessage)
-}
 
 export async function postSignup(data: SignupRequest): Promise<SignupResponse> {
   const res = await apiClient.post<ApiResponse<SignupResponse>>('/auth/signup', data)

--- a/src/api/response.ts
+++ b/src/api/response.ts
@@ -1,0 +1,9 @@
+import type { ApiResponse } from '@/types/api'
+
+export function unwrapApiResponse<T>(response: ApiResponse<T>, fallbackMessage: string): T {
+  if (response.success && response.data !== undefined) {
+    return response.data
+  }
+
+  throw new Error(response.message || fallbackMessage)
+}

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -3,9 +3,19 @@ import { unwrapApiResponse } from './response'
 import type { ApiResponse } from '@/types/api'
 import type { MyProfile, UpdateProfileRequest } from '@/types/user'
 
+interface RawMyProfileResponse {
+  userId: number
+  email: string
+  nickname: string
+  bio: string | null
+  profileImageUrl: string | null
+  createdAt: string
+  nickname_changeable_at: string | null
+}
+
 // backend returns nickname_changeable_at (snake_case via @JsonProperty)
 // normalize to camelCase here so the rest of the app stays consistent
-function normalizeProfile(raw: MyProfile & { nickname_changeable_at?: string | null }): MyProfile {
+function normalizeProfile(raw: RawMyProfileResponse): MyProfile {
   return {
     userId: raw.userId,
     email: raw.email,
@@ -13,18 +23,18 @@ function normalizeProfile(raw: MyProfile & { nickname_changeable_at?: string | n
     bio: raw.bio ?? null,
     profileImageUrl: raw.profileImageUrl ?? null,
     createdAt: raw.createdAt,
-    nicknameChangeableAt: raw.nickname_changeable_at ?? null,
+    nicknameChangeableAt: raw.nickname_changeable_at,
   }
 }
 
 export async function getMyProfile(): Promise<MyProfile> {
-  const res = await apiClient.get<ApiResponse<any>>('/users/me')
+  const res = await apiClient.get<ApiResponse<RawMyProfileResponse>>('/users/me')
   const raw = unwrapApiResponse(res.data, '프로필 조회에 실패했습니다.')
   return normalizeProfile(raw)
 }
 
 export async function updateProfile(data: UpdateProfileRequest): Promise<MyProfile> {
-  const res = await apiClient.patch<ApiResponse<any>>('/users/me', data)
+  const res = await apiClient.patch<ApiResponse<RawMyProfileResponse>>('/users/me', data)
   const raw = unwrapApiResponse(res.data, '프로필 수정에 실패했습니다.')
   return normalizeProfile(raw)
 }

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -1,0 +1,30 @@
+import { apiClient } from './client'
+import { unwrapApiResponse } from './response'
+import type { ApiResponse } from '@/types/api'
+import type { MyProfile, UpdateProfileRequest } from '@/types/user'
+
+// backend returns nickname_changeable_at (snake_case via @JsonProperty)
+// normalize to camelCase here so the rest of the app stays consistent
+function normalizeProfile(raw: MyProfile & { nickname_changeable_at?: string | null }): MyProfile {
+  return {
+    userId: raw.userId,
+    email: raw.email,
+    nickname: raw.nickname,
+    bio: raw.bio ?? null,
+    profileImageUrl: raw.profileImageUrl ?? null,
+    createdAt: raw.createdAt,
+    nicknameChangeableAt: raw.nickname_changeable_at ?? null,
+  }
+}
+
+export async function getMyProfile(): Promise<MyProfile> {
+  const res = await apiClient.get<ApiResponse<any>>('/users/me')
+  const raw = unwrapApiResponse(res.data, '프로필 조회에 실패했습니다.')
+  return normalizeProfile(raw)
+}
+
+export async function updateProfile(data: UpdateProfileRequest): Promise<MyProfile> {
+  const res = await apiClient.patch<ApiResponse<any>>('/users/me', data)
+  const raw = unwrapApiResponse(res.data, '프로필 수정에 실패했습니다.')
+  return normalizeProfile(raw)
+}

--- a/src/components/layout/Header.module.css
+++ b/src/components/layout/Header.module.css
@@ -197,13 +197,66 @@
   top: calc(100% + 10px);
   right: 0;
   z-index: 20;
-  display: grid;
-  min-width: 168px;
-  padding: 8px;
+  width: 220px;
+  overflow: hidden;
   border: 1px solid var(--border);
-  border-radius: 16px;
+  border-radius: 14px;
   background: var(--surface);
-  box-shadow: var(--sh-2);
+  box-shadow: var(--sh-3);
+}
+
+.profileMenuHeader {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.profileMenuHeaderAvatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  background: #ff8a65;
+  color: white;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.profileMenuHeaderInfo {
+  min-width: 0;
+}
+
+.profileMenuHeaderName {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.profileMenuHeaderEmail {
+  font-size: 11px;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-top: 1px;
+}
+
+.profileMenuItems {
+  padding: 6px;
+}
+
+.profileMenuDivider {
+  height: 1px;
+  background: var(--border);
+  margin: 4px 0;
 }
 
 .profileMenuItem {
@@ -211,13 +264,13 @@
   align-items: center;
   gap: 10px;
   width: 100%;
-  min-height: 42px;
+  min-height: 40px;
   padding: 0 12px;
   border: none;
-  border-radius: 12px;
+  border-radius: 9px;
   background: transparent;
   color: var(--text);
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 600;
   text-decoration: none;
   text-align: left;
@@ -232,11 +285,11 @@
 }
 
 .profileMenuItemDanger {
-  color: var(--danger);
+  color: var(--coral-600);
 }
 
 .profileMenuItemDanger:hover {
-  background: color-mix(in srgb, var(--danger) 8%, var(--surface));
+  background: color-mix(in srgb, var(--coral-600) 8%, var(--surface));
 }
 
 .profileMenuItem:disabled {

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -232,26 +232,38 @@ export default function Header() {
 
           {isProfileMenuOpen && (
             <div className={styles.profileMenu} role="menu" aria-label="프로필 메뉴">
-              <Link
-                to="/profile"
-                role="menuitem"
-                className={styles.profileMenuItem}
-                onClick={handleMenuClose}
-              >
-                <ProfileMenuIcon name="user" />
-                <span>마이페이지</span>
-              </Link>
+              <div className={styles.profileMenuHeader}>
+                <span className={styles.profileMenuHeaderAvatar}>{initial}</span>
+                <div className={styles.profileMenuHeaderInfo}>
+                  <div className={styles.profileMenuHeaderName}>{user?.nickname}</div>
+                  <div className={styles.profileMenuHeaderEmail}>{user?.email}</div>
+                </div>
+              </div>
 
-              <button
-                type="button"
-                role="menuitem"
-                className={cn(styles.profileMenuItem, styles.profileMenuItemDanger)}
-                onClick={handleLogout}
-                disabled={isLoggingOut}
-              >
-                <ProfileMenuIcon name="logout" />
-                <span>{isLoggingOut ? '로그아웃 중...' : '로그아웃'}</span>
-              </button>
+              <div className={styles.profileMenuItems}>
+                <Link
+                  to="/profile"
+                  role="menuitem"
+                  className={styles.profileMenuItem}
+                  onClick={handleMenuClose}
+                >
+                  <ProfileMenuIcon name="user" />
+                  <span>마이페이지</span>
+                </Link>
+
+                <div className={styles.profileMenuDivider} role="separator" />
+
+                <button
+                  type="button"
+                  role="menuitem"
+                  className={cn(styles.profileMenuItem, styles.profileMenuItemDanger)}
+                  onClick={handleLogout}
+                  disabled={isLoggingOut}
+                >
+                  <ProfileMenuIcon name="logout" />
+                  <span>{isLoggingOut ? '로그아웃 중...' : '로그아웃'}</span>
+                </button>
+              </div>
             </div>
           )}
         </div>

--- a/src/components/profile/EditProfileModal.module.css
+++ b/src/components/profile/EditProfileModal.module.css
@@ -143,10 +143,14 @@
   border-color: var(--coral-400);
 }
 
-.input:disabled {
+.input:read-only {
   background: var(--surface-2);
   color: var(--text-muted);
   cursor: not-allowed;
+}
+
+.inputError {
+  border-color: var(--danger);
 }
 
 .cooldownMsg {
@@ -173,10 +177,19 @@
   border-color: var(--coral-400);
 }
 
+.textareaError {
+  border-color: var(--danger);
+}
+
 .counter {
   font-size: 11px;
   color: var(--text-dim);
   font-family: 'Geist', sans-serif;
+}
+
+.fieldError {
+  font-size: 12px;
+  color: var(--danger);
 }
 
 .errorMsg {

--- a/src/components/profile/EditProfileModal.module.css
+++ b/src/components/profile/EditProfileModal.module.css
@@ -1,0 +1,246 @@
+.backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  background: rgba(20, 18, 12, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+
+.dialog {
+  width: 100%;
+  max-width: 520px;
+  background: var(--surface);
+  border-radius: 16px;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.22);
+  overflow: hidden;
+}
+
+/* ── Header ── */
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 24px;
+  border-bottom: 1px solid var(--border);
+}
+
+.headerTitle {
+  font-size: 16px;
+  font-weight: 700;
+  margin: 0;
+  color: var(--text);
+}
+
+.closeBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+  transition: background-color 150ms ease;
+}
+
+.closeBtn:hover {
+  background: var(--surface-2);
+}
+
+/* ── Body ── */
+.body {
+  padding: 24px 24px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.avatarRow {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+}
+
+.avatarPreview {
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #ff8a65, #ff5a2b);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  font-size: 30px;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.avatarLabel {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text);
+  margin-bottom: 4px;
+}
+
+.avatarNote {
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+/* ── Field ── */
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.fieldHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.label {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--text-muted);
+}
+
+.hintText {
+  font-size: 11px;
+  color: var(--text-dim);
+  font-weight: 600;
+}
+
+.cooldownBadge {
+  font-size: 11px;
+  color: #a86a00;
+  font-weight: 700;
+}
+
+.input {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--text);
+  font-size: 14px;
+  font-weight: 600;
+  font-family: inherit;
+  outline: none;
+  transition: border-color 150ms ease;
+}
+
+.input:focus {
+  border-color: var(--coral-400);
+}
+
+.input:disabled {
+  background: var(--surface-2);
+  color: var(--text-muted);
+  cursor: not-allowed;
+}
+
+.cooldownMsg {
+  font-size: 11px;
+  color: var(--text-dim);
+}
+
+.textarea {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--text);
+  font-size: 14px;
+  font-family: inherit;
+  line-height: 1.5;
+  resize: none;
+  outline: none;
+  transition: border-color 150ms ease;
+}
+
+.textarea:focus {
+  border-color: var(--coral-400);
+}
+
+.counter {
+  font-size: 11px;
+  color: var(--text-dim);
+  font-family: 'Geist', sans-serif;
+}
+
+.errorMsg {
+  font-size: 12px;
+  color: var(--danger);
+}
+
+/* ── Footer ── */
+.footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 16px 24px;
+  background: var(--surface-2);
+  border-top: 1px solid var(--border);
+}
+
+.cancelBtn {
+  background: transparent;
+  color: var(--text-muted);
+  border: 1px solid var(--border-strong);
+  padding: 9px 16px;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background-color 150ms ease;
+}
+
+.cancelBtn:hover {
+  background: var(--surface);
+}
+
+.saveBtn {
+  background: var(--ink-800);
+  color: white;
+  border: none;
+  padding: 9px 20px;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 700;
+  font-family: inherit;
+  cursor: pointer;
+  transition: opacity 150ms ease;
+}
+
+.saveBtn:hover:not(:disabled) {
+  opacity: 0.88;
+}
+
+.saveBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+@media (max-width: 560px) {
+  .backdrop {
+    padding: 0;
+    align-items: flex-end;
+  }
+
+  .dialog {
+    max-width: 100%;
+    border-radius: 20px 20px 0 0;
+  }
+}

--- a/src/components/profile/EditProfileModal.tsx
+++ b/src/components/profile/EditProfileModal.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useRef, useState } from 'react'
+import { useUpdateProfile } from '@/hooks/useProfile'
+import type { MyProfile } from '@/types/user'
+import styles from './EditProfileModal.module.css'
+
+interface Props {
+  profile: MyProfile
+  onClose: () => void
+}
+
+function nicknameRemainingDays(nicknameChangeableAt: string | null): number | null {
+  if (!nicknameChangeableAt) return null
+  const changeableAt = new Date(nicknameChangeableAt)
+  if (changeableAt <= new Date()) return null
+  const diffMs = changeableAt.getTime() - Date.now()
+  return Math.ceil(diffMs / (1000 * 60 * 60 * 24))
+}
+
+export default function EditProfileModal({ profile, onClose }: Props) {
+  const [nickname, setNickname] = useState(profile.nickname)
+  const [bio, setBio] = useState(profile.bio ?? '')
+  const dialogRef = useRef<HTMLDivElement>(null)
+
+  const { mutate, isPending, error } = useUpdateProfile()
+
+  const remainingDays = nicknameRemainingDays(profile.nicknameChangeableAt)
+  const isNicknameLocked = remainingDays !== null
+  const nicknameChanged = nickname.trim() !== profile.nickname
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [onClose])
+
+  const handleBackdropClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) onClose()
+  }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (isPending) return
+    if (nicknameChanged && isNicknameLocked) return
+    mutate(
+      { nickname: nickname.trim(), bio: bio.trim() || null },
+      { onSuccess: onClose },
+    )
+  }
+
+  return (
+    <div className={styles.backdrop} onClick={handleBackdropClick}>
+      <div
+        ref={dialogRef}
+        className={styles.dialog}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="edit-profile-title"
+      >
+        <div className={styles.header}>
+          <h3 id="edit-profile-title" className={styles.headerTitle}>프로필 수정</h3>
+          <button type="button" className={styles.closeBtn} onClick={onClose} aria-label="닫기">
+            ×
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit}>
+          <div className={styles.body}>
+            {/* Avatar preview */}
+            <div className={styles.avatarRow}>
+              <div className={styles.avatarPreview}>{profile.nickname[0]}</div>
+              <div>
+                <div className={styles.avatarLabel}>프로필 사진</div>
+                <div className={styles.avatarNote}>이미지 업로드는 추후 지원 예정입니다</div>
+              </div>
+            </div>
+
+            {/* Nickname */}
+            <div className={styles.field}>
+              <div className={styles.fieldHeader}>
+                <label htmlFor="edit-nickname" className={styles.label}>닉네임</label>
+                {isNicknameLocked ? (
+                  <span className={styles.cooldownBadge}>{remainingDays}일 후 변경 가능</span>
+                ) : (
+                  <span className={styles.hintText}>30일에 한 번 변경 가능</span>
+                )}
+              </div>
+              <input
+                id="edit-nickname"
+                className={styles.input}
+                value={nickname}
+                onChange={(e) => setNickname(e.target.value)}
+                maxLength={20}
+                disabled={isNicknameLocked}
+                autoComplete="off"
+              />
+              {isNicknameLocked && (
+                <span className={styles.cooldownMsg}>현재 닉네임 변경이 제한된 기간입니다</span>
+              )}
+            </div>
+
+            {/* Bio */}
+            <div className={styles.field}>
+              <div className={styles.fieldHeader}>
+                <label htmlFor="edit-bio" className={styles.label}>한 줄 소개</label>
+                <span className={styles.counter}>{bio.length}/100</span>
+              </div>
+              <textarea
+                id="edit-bio"
+                className={styles.textarea}
+                value={bio}
+                onChange={(e) => setBio(e.target.value)}
+                maxLength={100}
+                rows={2}
+              />
+            </div>
+
+            {error && (
+              <p className={styles.errorMsg}>저장 중 오류가 발생했습니다. 다시 시도해주세요.</p>
+            )}
+          </div>
+
+          <div className={styles.footer}>
+            <button type="button" className={styles.cancelBtn} onClick={onClose}>
+              취소
+            </button>
+            <button
+              type="submit"
+              className={styles.saveBtn}
+              disabled={isPending || (nicknameChanged && isNicknameLocked)}
+            >
+              {isPending ? '저장 중...' : '저장'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/src/components/profile/EditProfileModal.tsx
+++ b/src/components/profile/EditProfileModal.tsx
@@ -1,11 +1,20 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect } from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import {
+  applyValidationFieldErrors,
+  getApiErrorPayload,
+  type ValidationFieldErrors,
+} from '@/components/auth/authFormErrors'
 import { useUpdateProfile } from '@/hooks/useProfile'
 import type { MyProfile } from '@/types/user'
+import { editProfileSchema, type EditProfileFormValues } from './editProfileSchema'
 import styles from './EditProfileModal.module.css'
 
 interface Props {
   profile: MyProfile
   onClose: () => void
+  onSaved: (message: string) => void
 }
 
 function nicknameRemainingDays(nicknameChangeableAt: string | null): number | null {
@@ -16,16 +25,33 @@ function nicknameRemainingDays(nicknameChangeableAt: string | null): number | nu
   return Math.ceil(diffMs / (1000 * 60 * 60 * 24))
 }
 
-export default function EditProfileModal({ profile, onClose }: Props) {
-  const [nickname, setNickname] = useState(profile.nickname)
-  const [bio, setBio] = useState(profile.bio ?? '')
-  const dialogRef = useRef<HTMLDivElement>(null)
+const DEFAULT_SAVE_ERROR_MESSAGE = '저장 중 오류가 발생했습니다. 다시 시도해주세요.'
 
-  const { mutate, isPending, error } = useUpdateProfile()
+export default function EditProfileModal({ profile, onClose, onSaved }: Props) {
+  const { mutateAsync, isPending } = useUpdateProfile()
+  const {
+    register,
+    handleSubmit,
+    setError,
+    clearErrors,
+    watch,
+    formState: { errors },
+  } = useForm<EditProfileFormValues>({
+    resolver: zodResolver(editProfileSchema),
+    defaultValues: {
+      nickname: profile.nickname,
+      bio: profile.bio ?? '',
+    },
+  })
+
+  const nickname = watch('nickname') ?? profile.nickname
+  const bio = watch('bio') ?? profile.bio ?? ''
 
   const remainingDays = nicknameRemainingDays(profile.nicknameChangeableAt)
   const isNicknameLocked = remainingDays !== null
   const nicknameChanged = nickname.trim() !== profile.nickname
+  const bioChanged = bio.trim() !== (profile.bio ?? '')
+  const hasChanges = nicknameChanged || bioChanged
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -39,25 +65,51 @@ export default function EditProfileModal({ profile, onClose }: Props) {
     if (e.target === e.currentTarget) onClose()
   }
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault()
-    if (isPending) return
-    if (nicknameChanged && isNicknameLocked) return
-    mutate(
-      { nickname: nickname.trim(), bio: bio.trim() || null },
-      { onSuccess: onClose },
-    )
+  const onSubmit = async (values: EditProfileFormValues) => {
+    clearErrors('root')
+
+    if (!hasChanges) {
+      return
+    }
+
+    if (nicknameChanged && isNicknameLocked) {
+      setError('nickname', { message: '현재 닉네임 변경이 제한된 기간입니다.' })
+      return
+    }
+
+    try {
+      await mutateAsync({
+        nickname: isNicknameLocked ? profile.nickname : values.nickname.trim(),
+        bio: values.bio.trim() || null,
+      })
+      onSaved('프로필이 저장되었어요.')
+      onClose()
+    } catch (err) {
+      const apiError = getApiErrorPayload<ValidationFieldErrors>(err)
+
+      if (!apiError) {
+        const message = err instanceof Error ? err.message : DEFAULT_SAVE_ERROR_MESSAGE
+        setError('root', { message })
+        return
+      }
+
+      if (apiError.errorCode === 'VALIDATION_FAILED') {
+        const fieldErrors = apiError.data ?? {}
+        applyValidationFieldErrors(setError, fieldErrors)
+
+        if (Object.keys(fieldErrors).length === 0) {
+          setError('root', { message: apiError.message ?? DEFAULT_SAVE_ERROR_MESSAGE })
+        }
+        return
+      }
+
+      setError('root', { message: apiError.message ?? DEFAULT_SAVE_ERROR_MESSAGE })
+    }
   }
 
   return (
     <div className={styles.backdrop} onClick={handleBackdropClick}>
-      <div
-        ref={dialogRef}
-        className={styles.dialog}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="edit-profile-title"
-      >
+      <div className={styles.dialog} role="dialog" aria-modal="true" aria-labelledby="edit-profile-title">
         <div className={styles.header}>
           <h3 id="edit-profile-title" className={styles.headerTitle}>프로필 수정</h3>
           <button type="button" className={styles.closeBtn} onClick={onClose} aria-label="닫기">
@@ -65,18 +117,16 @@ export default function EditProfileModal({ profile, onClose }: Props) {
           </button>
         </div>
 
-        <form onSubmit={handleSubmit}>
+        <form onSubmit={handleSubmit(onSubmit)}>
           <div className={styles.body}>
-            {/* Avatar preview */}
             <div className={styles.avatarRow}>
-              <div className={styles.avatarPreview}>{profile.nickname[0]}</div>
+              <div className={styles.avatarPreview}>{nickname.trim()[0] ?? profile.nickname[0] ?? '?'}</div>
               <div>
                 <div className={styles.avatarLabel}>프로필 사진</div>
                 <div className={styles.avatarNote}>이미지 업로드는 추후 지원 예정입니다</div>
               </div>
             </div>
 
-            {/* Nickname */}
             <div className={styles.field}>
               <div className={styles.fieldHeader}>
                 <label htmlFor="edit-nickname" className={styles.label}>닉네임</label>
@@ -88,19 +138,19 @@ export default function EditProfileModal({ profile, onClose }: Props) {
               </div>
               <input
                 id="edit-nickname"
-                className={styles.input}
-                value={nickname}
-                onChange={(e) => setNickname(e.target.value)}
+                className={`${styles.input} ${errors.nickname ? styles.inputError : ''}`}
                 maxLength={20}
-                disabled={isNicknameLocked}
+                readOnly={isNicknameLocked}
+                aria-readonly={isNicknameLocked}
                 autoComplete="off"
+                {...register('nickname')}
               />
+              {errors.nickname && <span className={styles.fieldError}>{errors.nickname.message}</span>}
               {isNicknameLocked && (
                 <span className={styles.cooldownMsg}>현재 닉네임 변경이 제한된 기간입니다</span>
               )}
             </div>
 
-            {/* Bio */}
             <div className={styles.field}>
               <div className={styles.fieldHeader}>
                 <label htmlFor="edit-bio" className={styles.label}>한 줄 소개</label>
@@ -108,17 +158,15 @@ export default function EditProfileModal({ profile, onClose }: Props) {
               </div>
               <textarea
                 id="edit-bio"
-                className={styles.textarea}
-                value={bio}
-                onChange={(e) => setBio(e.target.value)}
+                className={`${styles.textarea} ${errors.bio ? styles.textareaError : ''}`}
                 maxLength={100}
                 rows={2}
+                {...register('bio')}
               />
+              {errors.bio && <span className={styles.fieldError}>{errors.bio.message}</span>}
             </div>
 
-            {error && (
-              <p className={styles.errorMsg}>저장 중 오류가 발생했습니다. 다시 시도해주세요.</p>
-            )}
+            {errors.root && <p className={styles.errorMsg}>{errors.root.message}</p>}
           </div>
 
           <div className={styles.footer}>
@@ -128,7 +176,7 @@ export default function EditProfileModal({ profile, onClose }: Props) {
             <button
               type="submit"
               className={styles.saveBtn}
-              disabled={isPending || (nicknameChanged && isNicknameLocked)}
+              disabled={isPending || !hasChanges || (nicknameChanged && isNicknameLocked)}
             >
               {isPending ? '저장 중...' : '저장'}
             </button>

--- a/src/components/profile/editProfileSchema.ts
+++ b/src/components/profile/editProfileSchema.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod'
+
+export const editProfileSchema = z.object({
+  nickname: z
+    .string()
+    .trim()
+    .min(1, '닉네임을 입력해주세요.')
+    .min(2, '닉네임은 2자 이상이어야 합니다.')
+    .max(20, '닉네임은 20자 이하여야 합니다.'),
+  bio: z.string().max(100, '한 줄 소개는 100자 이하여야 합니다.'),
+})
+
+export type EditProfileFormValues = z.infer<typeof editProfileSchema>

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -1,0 +1,30 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+
+import { getMyProfile, updateProfile } from '@/api/user'
+import { useAuthStore } from '@/stores/authStore'
+import type { UpdateProfileRequest } from '@/types/user'
+
+const MY_PROFILE_QUERY_KEY = ['myProfile'] as const
+
+export function useMyProfile() {
+  return useQuery({
+    queryKey: MY_PROFILE_QUERY_KEY,
+    queryFn: getMyProfile,
+  })
+}
+
+export function useUpdateProfile() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (data: UpdateProfileRequest) => updateProfile(data),
+    onSuccess: (updatedProfile) => {
+      queryClient.setQueryData(MY_PROFILE_QUERY_KEY, updatedProfile)
+
+      const { user, setUser } = useAuthStore.getState()
+      if (user) {
+        setUser({ ...user, nickname: updatedProfile.nickname })
+      }
+    },
+  })
+}

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -20,6 +20,7 @@ export function useUpdateProfile() {
     mutationFn: (data: UpdateProfileRequest) => updateProfile(data),
     onSuccess: (updatedProfile) => {
       queryClient.setQueryData(MY_PROFILE_QUERY_KEY, updatedProfile)
+      void queryClient.invalidateQueries({ queryKey: MY_PROFILE_QUERY_KEY })
 
       const { user, setUser } = useAuthStore.getState()
       if (user) {

--- a/src/pages/ProfilePage.module.css
+++ b/src/pages/ProfilePage.module.css
@@ -17,6 +17,15 @@
   color: var(--text-muted);
 }
 
+.spinner {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 3px solid var(--border-strong);
+  border-top-color: var(--coral-500);
+  animation: spin 0.7s linear infinite;
+}
+
 .inner {
   max-width: 880px;
   margin: 0 auto;
@@ -25,6 +34,17 @@
 
 .pageHeading {
   margin-bottom: 28px;
+}
+
+.successBanner {
+  margin-bottom: 16px;
+  padding: 12px 14px;
+  border: 1px solid rgba(22, 163, 74, 0.18);
+  border-radius: 12px;
+  background: var(--success-bg);
+  color: var(--success);
+  font-size: 13px;
+  font-weight: 700;
 }
 
 .pageTitle {
@@ -105,9 +125,15 @@
   color: var(--text);
 }
 
-.daysTag {
-  font-size: 12px;
+.daysBadge {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 10px;
+  border-radius: 20px;
+  background: var(--coral-100);
+  border: 1px solid var(--coral-200);
   color: var(--coral-700);
+  font-size: 11px;
   font-weight: 700;
   white-space: nowrap;
 }
@@ -119,39 +145,37 @@
 .bio {
   font-size: 14px;
   color: var(--text-muted);
-  margin: 6px 0 0;
-  line-height: 1.5;
+  margin: 10px 0 0;
+  line-height: 1.6;
 }
 
 .bioEmpty {
-  font-size: 14px;
+  font-size: 13px;
   color: var(--text-dim);
-  margin: 6px 0 0;
+  margin: 10px 0 0;
   font-style: italic;
 }
 
-.metaRow {
+.metaList {
   display: flex;
-  align-items: center;
-  gap: 18px;
-  margin-top: 14px;
-  font-size: 13px;
-  color: var(--text-dim);
-  flex-wrap: wrap;
+  flex-direction: column;
+  gap: 7px;
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
 }
 
 .metaItem {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--text-dim);
 }
 
-.metaDot {
-  width: 3px;
-  height: 3px;
-  border-radius: 50%;
-  background: var(--text-dim);
+.metaIcon {
   flex-shrink: 0;
+  color: var(--text-muted);
 }
 
 .editBtn {
@@ -173,6 +197,12 @@
 
 .editBtn:hover {
   background: var(--surface-2);
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 @media (max-width: 640px) {

--- a/src/pages/ProfilePage.module.css
+++ b/src/pages/ProfilePage.module.css
@@ -1,0 +1,215 @@
+.page {
+  flex: 1;
+  overflow: auto;
+  padding: 40px 0;
+}
+
+.loadingWrapper {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 80px 40px;
+}
+
+.errorText {
+  font-size: 14px;
+  color: var(--text-muted);
+}
+
+.inner {
+  max-width: 880px;
+  margin: 0 auto;
+  padding: 0 32px;
+}
+
+.pageHeading {
+  margin-bottom: 28px;
+}
+
+.pageTitle {
+  font-size: 32px;
+  font-weight: 800;
+  letter-spacing: -0.025em;
+  margin: 0;
+  color: var(--text);
+}
+
+.pageSubtitle {
+  font-size: 13px;
+  color: var(--text-muted);
+  margin-top: 4px;
+}
+
+/* ── Profile card ── */
+.card {
+  position: relative;
+  overflow: hidden;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  box-shadow: var(--sh-2);
+  padding: 32px;
+}
+
+.halo {
+  position: absolute;
+  top: -160px;
+  right: -120px;
+  width: 380px;
+  height: 380px;
+  border-radius: 50%;
+  background: radial-gradient(circle, var(--coral-100), transparent 70%);
+  pointer-events: none;
+}
+
+.cardBody {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 28px;
+}
+
+.avatar {
+  width: 112px;
+  height: 112px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #ff8a65, #ff5a2b);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  font-size: 48px;
+  font-weight: 700;
+  flex-shrink: 0;
+  box-shadow: 0 8px 24px -10px rgba(255, 90, 43, 0.45);
+}
+
+.info {
+  flex: 1;
+  min-width: 0;
+}
+
+.nameRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.nickname {
+  font-size: 26px;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  margin: 0;
+  color: var(--text);
+}
+
+.daysTag {
+  font-size: 12px;
+  color: var(--coral-700);
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.daysNum {
+  font-family: 'Geist', sans-serif;
+}
+
+.bio {
+  font-size: 14px;
+  color: var(--text-muted);
+  margin: 6px 0 0;
+  line-height: 1.5;
+}
+
+.bioEmpty {
+  font-size: 14px;
+  color: var(--text-dim);
+  margin: 6px 0 0;
+  font-style: italic;
+}
+
+.metaRow {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  margin-top: 14px;
+  font-size: 13px;
+  color: var(--text-dim);
+  flex-wrap: wrap;
+}
+
+.metaItem {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.metaDot {
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: var(--text-dim);
+  flex-shrink: 0;
+}
+
+.editBtn {
+  background: var(--surface);
+  border: 1px solid var(--border-strong);
+  color: var(--text);
+  font-weight: 600;
+  font-size: 13px;
+  font-family: inherit;
+  padding: 10px 18px;
+  border-radius: 10px;
+  flex-shrink: 0;
+  align-self: flex-start;
+  cursor: pointer;
+  transition:
+    background-color 150ms ease,
+    border-color 150ms ease;
+}
+
+.editBtn:hover {
+  background: var(--surface-2);
+}
+
+@media (max-width: 640px) {
+  .page {
+    padding: 24px 0;
+  }
+
+  .inner {
+    padding: 0 16px;
+  }
+
+  .pageTitle {
+    font-size: 24px;
+  }
+
+  .card {
+    padding: 20px;
+  }
+
+  .cardBody {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 16px;
+  }
+
+  .avatar {
+    width: 80px;
+    height: 80px;
+    font-size: 34px;
+  }
+
+  .nickname {
+    font-size: 22px;
+  }
+
+  .editBtn {
+    align-self: stretch;
+    text-align: center;
+  }
+}

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useMyProfile } from '@/hooks/useProfile'
 import EditProfileModal from '@/components/profile/EditProfileModal'
 import styles from './ProfilePage.module.css'
@@ -25,20 +25,24 @@ function formatJoinDate(createdAt: string): string {
 export default function ProfilePage() {
   const { data: profile, isLoading, isError } = useMyProfile()
   const [isModalOpen, setIsModalOpen] = useState(false)
+  const [successMessage, setSuccessMessage] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!successMessage) {
+      return
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setSuccessMessage(null)
+    }, 3000)
+
+    return () => window.clearTimeout(timeoutId)
+  }, [successMessage])
 
   if (isLoading) {
     return (
       <div className={styles.loadingWrapper}>
-        <div
-          style={{
-            width: 28,
-            height: 28,
-            borderRadius: '50%',
-            border: '3px solid var(--border-strong)',
-            borderTopColor: 'var(--coral-500)',
-            animation: 'spin 0.7s linear infinite',
-          }}
-        />
+        <div className={styles.spinner} />
       </div>
     )
   }
@@ -55,56 +59,68 @@ export default function ProfilePage() {
   const days = daysSinceJoined(profile.createdAt)
 
   return (
-    <>
-      <style>{`@keyframes spin { to { transform: rotate(360deg) } }`}</style>
-      <div className={styles.page}>
-        <div className={styles.inner}>
-          <div className={styles.pageHeading}>
-            <h1 className={styles.pageTitle}>마이페이지</h1>
-            <p className={styles.pageSubtitle}>프로필 정보를 관리하세요</p>
-          </div>
+    <div className={styles.page}>
+      <div className={styles.inner}>
+        <div className={styles.pageHeading}>
+          <h1 className={styles.pageTitle}>마이페이지</h1>
+          <p className={styles.pageSubtitle}>프로필 정보를 관리하세요</p>
+        </div>
 
-          <div className={styles.card}>
-            <div className={styles.halo} aria-hidden="true" />
-            <div className={styles.cardBody}>
-              <div className={styles.avatar}>{initial}</div>
+        {successMessage && <div className={styles.successBanner}>{successMessage}</div>}
 
-              <div className={styles.info}>
-                <div className={styles.nameRow}>
-                  <h2 className={styles.nickname}>{profile.nickname}</h2>
-                  <span className={styles.daysTag}>
-                    · 함께한 지 <span className={styles.daysNum}>{days}일째</span>
-                  </span>
-                </div>
+        <div className={styles.card}>
+          <div className={styles.halo} aria-hidden="true" />
+          <div className={styles.cardBody}>
+            <div className={styles.avatar}>{initial}</div>
 
-                {profile.bio ? (
-                  <p className={styles.bio}>{profile.bio}</p>
-                ) : (
-                  <p className={styles.bioEmpty}>한 줄 소개를 추가해보세요</p>
-                )}
-
-                <div className={styles.metaRow}>
-                  <span className={styles.metaItem}>
-                    <span>✉</span>
-                    <span>{profile.email}</span>
-                  </span>
-                  <span className={styles.metaDot} />
-                  <span className={styles.metaItem}>
-                    <span>📅</span>
-                    <span>{formatJoinDate(profile.createdAt)} 가입</span>
-                  </span>
-                </div>
+            <div className={styles.info}>
+              <div className={styles.nameRow}>
+                <h2 className={styles.nickname}>{profile.nickname}</h2>
+                <span className={styles.daysBadge}>
+                  함께한 지 <span className={styles.daysNum}>{days}일째</span>
+                </span>
               </div>
 
-              <button type="button" className={styles.editBtn} onClick={() => setIsModalOpen(true)}>
-                ✎ 프로필 수정
-              </button>
+              {profile.bio ? (
+                <p className={styles.bio}>{profile.bio}</p>
+              ) : (
+                <p className={styles.bioEmpty}>한 줄 소개를 추가해보세요</p>
+              )}
+
+              <div className={styles.metaList}>
+                <div className={styles.metaItem}>
+                  <svg className={styles.metaIcon} width="15" height="15" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                    <rect x="1.5" y="3.5" width="13" height="9" rx="1.5" stroke="currentColor" strokeWidth="1.3"/>
+                    <path d="M1.5 5.5L8 9.5L14.5 5.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round"/>
+                  </svg>
+                  <span>{profile.email}</span>
+                </div>
+                <div className={styles.metaItem}>
+                  <svg className={styles.metaIcon} width="15" height="15" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                    <rect x="1.5" y="3" width="13" height="11" rx="1.5" stroke="currentColor" strokeWidth="1.3"/>
+                    <path d="M1.5 7H14.5" stroke="currentColor" strokeWidth="1.3"/>
+                    <path d="M5 1.5V4.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"/>
+                    <path d="M11 1.5V4.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round"/>
+                  </svg>
+                  <span>{formatJoinDate(profile.createdAt)} 가입</span>
+                </div>
+              </div>
             </div>
+
+            <button type="button" className={styles.editBtn} onClick={() => setIsModalOpen(true)}>
+              ✎ 프로필 수정
+            </button>
           </div>
         </div>
       </div>
 
-      {isModalOpen && <EditProfileModal profile={profile} onClose={() => setIsModalOpen(false)} />}
-    </>
+      {isModalOpen && (
+        <EditProfileModal
+          profile={profile}
+          onClose={() => setIsModalOpen(false)}
+          onSaved={setSuccessMessage}
+        />
+      )}
+    </div>
   )
 }

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -1,3 +1,110 @@
+import { useState } from 'react'
+import { useMyProfile } from '@/hooks/useProfile'
+import EditProfileModal from '@/components/profile/EditProfileModal'
+import styles from './ProfilePage.module.css'
+
+// function maskEmail(email: string): string {
+//   const atIndex = email.indexOf('@')
+//   if (atIndex <= 2) return email
+//   return email.slice(0, 2) + '•••' + email.slice(atIndex)
+// }
+
+function daysSinceJoined(createdAt: string): number {
+  const diffMs = Date.now() - new Date(createdAt).getTime()
+  return Math.max(1, Math.floor(diffMs / (1000 * 60 * 60 * 24)) + 1)
+}
+
+function formatJoinDate(createdAt: string): string {
+  const d = new Date(createdAt)
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}.${m}.${day}`
+}
+
 export default function ProfilePage() {
-  return <div className="p-4 text-text-primary">프로필</div>
+  const { data: profile, isLoading, isError } = useMyProfile()
+  const [isModalOpen, setIsModalOpen] = useState(false)
+
+  if (isLoading) {
+    return (
+      <div className={styles.loadingWrapper}>
+        <div
+          style={{
+            width: 28,
+            height: 28,
+            borderRadius: '50%',
+            border: '3px solid var(--border-strong)',
+            borderTopColor: 'var(--coral-500)',
+            animation: 'spin 0.7s linear infinite',
+          }}
+        />
+      </div>
+    )
+  }
+
+  if (isError || !profile) {
+    return (
+      <div className={styles.loadingWrapper}>
+        <p className={styles.errorText}>프로필을 불러오지 못했습니다.</p>
+      </div>
+    )
+  }
+
+  const initial = profile.nickname[0]
+  const days = daysSinceJoined(profile.createdAt)
+
+  return (
+    <>
+      <style>{`@keyframes spin { to { transform: rotate(360deg) } }`}</style>
+      <div className={styles.page}>
+        <div className={styles.inner}>
+          <div className={styles.pageHeading}>
+            <h1 className={styles.pageTitle}>마이페이지</h1>
+            <p className={styles.pageSubtitle}>프로필 정보를 관리하세요</p>
+          </div>
+
+          <div className={styles.card}>
+            <div className={styles.halo} aria-hidden="true" />
+            <div className={styles.cardBody}>
+              <div className={styles.avatar}>{initial}</div>
+
+              <div className={styles.info}>
+                <div className={styles.nameRow}>
+                  <h2 className={styles.nickname}>{profile.nickname}</h2>
+                  <span className={styles.daysTag}>
+                    · 함께한 지 <span className={styles.daysNum}>{days}일째</span>
+                  </span>
+                </div>
+
+                {profile.bio ? (
+                  <p className={styles.bio}>{profile.bio}</p>
+                ) : (
+                  <p className={styles.bioEmpty}>한 줄 소개를 추가해보세요</p>
+                )}
+
+                <div className={styles.metaRow}>
+                  <span className={styles.metaItem}>
+                    <span>✉</span>
+                    <span>{profile.email}</span>
+                  </span>
+                  <span className={styles.metaDot} />
+                  <span className={styles.metaItem}>
+                    <span>📅</span>
+                    <span>{formatJoinDate(profile.createdAt)} 가입</span>
+                  </span>
+                </div>
+              </div>
+
+              <button type="button" className={styles.editBtn} onClick={() => setIsModalOpen(true)}>
+                ✎ 프로필 수정
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {isModalOpen && <EditProfileModal profile={profile} onClose={() => setIsModalOpen(false)} />}
+    </>
+  )
 }

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -10,6 +10,7 @@ interface AuthState {
   setAccessToken: (token: string) => void
   clearAuth: () => void
   setLoading: (loading: boolean) => void
+  setUser: (user: User) => void
 }
 
 export const useAuthStore = create<AuthState>((set) => ({
@@ -21,4 +22,5 @@ export const useAuthStore = create<AuthState>((set) => ({
   setAccessToken: (token) => set({ accessToken: token }),
   clearAuth: () => set({ accessToken: null, isAuthenticated: false, user: null }),
   setLoading: (loading) => set({ isLoading: loading }),
+  setUser: (user) => set({ user }),
 }))

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,14 @@
+export interface MyProfile {
+  userId: number
+  email: string
+  nickname: string
+  bio: string | null
+  profileImageUrl: string | null
+  createdAt: string
+  nicknameChangeableAt: string | null
+}
+
+export interface UpdateProfileRequest {
+  nickname: string
+  bio: string | null
+}


### PR DESCRIPTION
## ✅ 무엇을 변경했나요?

- 마이페이지(`/profile`) 구현
  - 아바타(이니셜), 닉네임, 함께한 일수(D+N), 한 줄 소개, 이메일, 가입일 표시
- 프로필 수정 모달 구현
  - 닉네임 및 한 줄 소개 수정 지원
  - 닉네임 30일 쿨다운 상태 UI 반영
- `react-hook-form` + `zod` 기반 폼 유효성 검사 및 API 에러 처리 추가
- `unwrapApiResponse` 공통 헬퍼 분리 (`src/api/response.ts`)
- 프로필 저장 후 `authStore` 닉네임 즉시 동기화
  - `useAuthStore.getState().setUser`
- 백엔드 응답의 `nickname_changeable_at`(snake_case)을 `nicknameChangeableAt`(camelCase)로 정규화
- `RawMyProfileResponse` 인터페이스 추가로 API 레이어 타입 안정성 강화

## 🎯 왜 변경했나요? (문제/배경)

- 사용자가 자신의 프로필 정보를 조회·수정할 수 있는 기능이 필요했음
- 백엔드에 `bio` 필드 및 닉네임 30일 쿨다운 정책(`nickname_changeable_at`)이 추가됨
- 프로필 이미지 업로드는 현재 백엔드 미지원 상태로, MVP 범위에서는 제외하고 추후 지원 예정 안내만 제공

## 🔗 관련 이슈

- Closes #13

## 🧪 테스트/검증 방법

- [x] 로컬 빌드/실행 확인
- [x] 핵심 시나리오 수동 테스트
- [ ] 단위/통합 테스트 추가 또는 수정

### 검증 시나리오

1. 마이페이지 진입 시 프로필 정보(닉네임, 한 줄 소개, 이메일, 가입일, D+N)가 정상 표시된다
2. 프로필 수정 모달에서 한 줄 소개 수정 후 저장 시 카드에 즉시 반영되고 성공 메시지가 표시된다
3. 닉네임 변경 쿨다운 중일 경우 닉네임 필드가 비활성화되고 `"N일 후 변경 가능"` 배지가 표시된다
4. 유효성 검사 실패(예: 닉네임 2자 미만) 시 필드 하단에 에러 메시지가 표시된다
5. ESC 키 또는 백드롭 클릭 시 모달이 정상적으로 닫힌다

## ✅ 체크리스트

- [x] 코드가 컴파일/빌드 됩니다
- [x] 불필요한 디버그 코드/로그를 제거했습니다
- [x] 에러 케이스를 고려했습니다
- [ ] (필요 시) 문서/주석을 업데이트했습니다
- [x] (Front-end) UI/상태 변경이 의도대로 동작합니다

## 📝 기타 공유사항

- `src/api/user.ts`의 `normalizeProfile`은 백엔드에서 전달하는 snake_case 필드를 앱 전역 camelCase 형태로 변환하는 단일 진입점입니다
- 후속 작업(To-do)
  - 백엔드 프로필 이미지 업로드 API 구현 후 프로필 수정 모달에 이미지 업로드 기능 추가 예정