### PR TITLE
[docs] #15 챌린지 생성·목록·상세·수정 화면 디자인 추가

### DIFF
--- a/design/v2/artboards-challenge-create.jsx
+++ b/design/v2/artboards-challenge-create.jsx
@@ -1,0 +1,515 @@
+// Routinely — Challenge Create (desktop web, v2 — spec'd 3-section structure)
+// Challenge + Routine 1:1, single page with 3 sections.
+// Category in section 1 only. Invite excluded (MVP).
+// Post-create: public → detail / private → invite-link modal.
+
+const LABEL = { fontSize: 12, fontWeight: 700, color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '.06em', display: 'block' };
+
+const SectionCard = ({ num, title, sub, required, children }) => (
+  <section className="r-card" style={{ padding: 28 }}>
+    <header style={{ display: 'flex', alignItems: 'flex-start', gap: 14, marginBottom: 20 }}>
+      <div style={{
+        width: 30, height: 30, borderRadius: 8, flexShrink: 0,
+        background: 'var(--coral-500)', color: 'white',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        fontFamily: 'Geist', fontSize: 14, fontWeight: 800,
+      }}>{num}</div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
+          <h3 style={{ fontSize: 18, fontWeight: 800, letterSpacing: '-0.015em', margin: 0 }}>{title}</h3>
+          {required && <span style={{ fontSize: 11, color: 'var(--coral-600)', fontWeight: 700 }}>· 필수</span>}
+        </div>
+        {sub && <p style={{ fontSize: 13, color: 'var(--text-muted)', margin: '4px 0 0' }}>{sub}</p>}
+      </div>
+    </header>
+    <div>{children}</div>
+  </section>
+);
+
+const FieldRow = ({ label, required, hint, error, children }) => (
+  <div style={{ marginBottom: 18 }}>
+    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 6 }}>
+      <label style={LABEL}>
+        {label} {required && <span style={{ color: 'var(--coral-600)' }}>*</span>}
+      </label>
+      {hint && <span style={{ fontSize: 11, color: 'var(--text-dim)', fontFamily: 'Geist' }}>{hint}</span>}
+    </div>
+    {children}
+    {error && <div style={{ fontSize: 11, color: 'var(--danger)', fontWeight: 600, marginTop: 6 }}>{error}</div>}
+  </div>
+);
+
+// ─── Main create screen ────────────────────────────
+const ChallengeCreateArtboard = () => (
+  <div style={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column', background: 'var(--bg)' }}>
+    <AppHeader active="challenges" />
+
+    {/* Action bar */}
+    <div style={{
+      height: 56, padding: '0 36px',
+      display: 'flex', alignItems: 'center', gap: 16,
+      borderBottom: '1px solid var(--border)', background: 'var(--surface)',
+    }}>
+      <button className="r-btn r-btn--ghost r-btn--sm" style={{ color: 'var(--text-muted)' }}>← 챌린지 목록</button>
+      <div style={{ flex: 1 }}/>
+      <span style={{ fontSize: 12, color: 'var(--text-dim)' }}>임시저장됨 · 18:42</span>
+    </div>
+
+    <div style={{ flex: 1, overflow: 'auto', padding: '40px 36px 60px' }}>
+      <div style={{ maxWidth: 820, margin: '0 auto' }}>
+        {/* Heading */}
+        <div style={{ marginBottom: 28 }}>
+          <div style={{ fontSize: 11, color: 'var(--coral-700)', textTransform: 'uppercase', letterSpacing: '.12em', fontWeight: 700 }}>NEW CHALLENGE</div>
+          <h1 style={{ fontSize: 40, fontWeight: 800, letterSpacing: '-0.025em', margin: '6px 0 0', lineHeight: 1.05 }}>
+            같이 할 사람, 모아볼까요?
+          </h1>
+          <p style={{ fontSize: 14, color: 'var(--text-muted)', marginTop: 10, maxWidth: 580, lineHeight: 1.55 }}>
+            챌린지는 하나의 루틴을 멤버들과 함께 수행하는 형식이에요. 3단계만 입력하면 시작할 수 있어요.
+          </p>
+        </div>
+
+        {/* Step indicator */}
+        <ol style={{ display: 'flex', gap: 8, listStyle: 'none', padding: 0, margin: '0 0 24px', fontSize: 12, color: 'var(--text-muted)', fontWeight: 600 }}>
+          {[
+            { n: 1, label: '기본 정보' },
+            { n: 2, label: '기간 · 참여' },
+            { n: 3, label: '루틴' },
+          ].map((s, i) => (
+            <li key={s.n} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <span style={{ fontFamily: 'Geist', color: 'var(--text)', fontWeight: 700 }}>0{s.n}</span>
+              <span>{s.label}</span>
+              {i < 2 && <span style={{ width: 18, height: 1, background: 'var(--border-strong)', marginLeft: 4 }}/>}
+            </li>
+          ))}
+        </ol>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
+          {/* ── Section 1: 기본 정보 ──────────────── */}
+          <SectionCard num={1} title="기본 정보" sub="챌린지의 이름과 카테고리, 분위기를 정해요">
+            <FieldRow label="챌린지 이름" required hint="9 / 100">
+              <input className="r-input" defaultValue="21일 아침 러닝" style={{ fontSize: 16, fontWeight: 600, padding: '11px 14px' }} maxLength={100}/>
+            </FieldRow>
+
+            <FieldRow label="카테고리" required hint="챌린지와 루틴 모두에 적용돼요">
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+                {ROUTINE_CATEGORIES.filter(c => c.id !== 'all').map(c => {
+                  const on = c.id === 'fitness';
+                  return (
+                    <button key={c.id} style={{
+                      display: 'inline-flex', alignItems: 'center', gap: 6,
+                      padding: '8px 14px', borderRadius: 999,
+                      border: on ? 'none' : '1.5px solid var(--border-strong)',
+                      background: on ? c.color : 'var(--surface)',
+                      color: on ? 'white' : 'var(--text)',
+                      fontFamily: 'inherit', fontSize: 13, fontWeight: 600, cursor: 'pointer',
+                    }}>
+                      <span>{c.emoji}</span><span>{c.name}</span>
+                    </button>
+                  );
+                })}
+              </div>
+            </FieldRow>
+
+            <FieldRow label="대표 이미지" hint="선택 · 챌린지 카드에 노출돼요">
+              <div style={{ display: 'flex', gap: 14, alignItems: 'flex-start' }}>
+                {/* Cover preview */}
+                <div style={{
+                  width: 140, height: 140, borderRadius: 16, flexShrink: 0,
+                  background: 'linear-gradient(135deg, var(--coral-500), var(--sunset-500))',
+                  position: 'relative', overflow: 'hidden',
+                  display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 56,
+                  color: 'white',
+                }}>
+                  🏃
+                  <div style={{ position: 'absolute', top: -30, right: -30, width: 90, height: 90, borderRadius: '50%', border: '2px solid rgba(255,255,255,.25)' }}/>
+                </div>
+                <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 8 }}>
+                  <div style={{ fontSize: 13, color: 'var(--text-muted)', lineHeight: 1.55 }}>
+                    이미지를 올리거나, 이모지로 간단히 표현할 수 있어요. JPG · PNG · 최대 5MB.
+                  </div>
+                  <div style={{ display: 'flex', gap: 8 }}>
+                    <button className="r-btn r-btn--sm" style={{ background: 'var(--text)', color: 'var(--surface)' }}>🖼 이미지 업로드</button>
+                    <button className="r-btn r-btn--sm" style={{ background: 'var(--surface-2)', color: 'var(--text)', border: '1px solid var(--border-strong)' }}>이모지 선택</button>
+                    <button className="r-btn r-btn--sm" style={{ background: 'transparent', color: 'var(--text-muted)' }}>제거</button>
+                  </div>
+                </div>
+              </div>
+            </FieldRow>
+          </SectionCard>
+
+          {/* ── Section 2: 기간 + 참여 설정 ──────── */}
+          <SectionCard num={2} title="기간 및 참여 설정" sub="언제 어떻게 모일지 정해요">
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 14 }}>
+              <FieldRow label="시작일" required>
+                <div className="r-input" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', cursor: 'pointer', fontSize: 14 }}>
+                  <span style={{ fontFamily: 'Geist', fontWeight: 600 }}>2026.05.27 (수)</span>
+                  <Icon name="calendar" size={15} color="var(--text-muted)"/>
+                </div>
+              </FieldRow>
+              <FieldRow label="종료일" required hint="21일">
+                <div className="r-input" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', cursor: 'pointer', fontSize: 14 }}>
+                  <span style={{ fontFamily: 'Geist', fontWeight: 600 }}>2026.06.16 (화)</span>
+                  <Icon name="calendar" size={15} color="var(--text-muted)"/>
+                </div>
+              </FieldRow>
+            </div>
+
+            <FieldRow label="최대 참여 인원" required hint="최소 2명">
+              <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+                <input type="range" min="2" max="50" defaultValue="12" style={{ flex: 1, accentColor: 'var(--coral-500)' }}/>
+                <div style={{
+                  minWidth: 72, textAlign: 'right',
+                  fontSize: 22, fontWeight: 800, fontFamily: 'Geist', color: 'var(--coral-600)',
+                }}>
+                  12<span style={{ fontSize: 12, color: 'var(--text-muted)', marginLeft: 4, fontWeight: 600 }}>명</span>
+                </div>
+              </div>
+              <div style={{ fontSize: 11, color: 'var(--text-dim)', marginTop: 6 }}>친근한 그룹은 5–15명을 추천해요</div>
+            </FieldRow>
+
+            <FieldRow label="공개 설정" required hint="비공개는 만든 후 초대 링크로 모집해요">
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                {[
+                  { v: 'public', icon: '🌍', label: '공개', sub: '공개 챌린지 목록에 노출돼요', on: true },
+                  { v: 'private', icon: '🔒', label: '비공개', sub: '초대 링크로만 참여 가능' },
+                ].map(o => (
+                  <div key={o.v} style={{
+                    display: 'flex', alignItems: 'center', gap: 14,
+                    padding: '14px 16px', borderRadius: 12,
+                    border: o.on ? '2px solid var(--coral-500)' : '1.5px solid var(--border-strong)',
+                    background: o.on ? 'var(--coral-50)' : 'transparent',
+                    cursor: 'pointer',
+                  }}>
+                    <span style={{ fontSize: 22 }}>{o.icon}</span>
+                    <div style={{ flex: 1 }}>
+                      <div style={{ fontSize: 14, fontWeight: 700 }}>{o.label}</div>
+                      <div style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 1 }}>{o.sub}</div>
+                    </div>
+                    <div style={{
+                      width: 20, height: 20, borderRadius: '50%',
+                      border: o.on ? 'none' : '2px solid var(--border-strong)',
+                      background: o.on ? 'var(--coral-500)' : 'transparent',
+                      display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+                    }}>{o.on && <Icon name="check" size={12} color="white" strokeWidth={3.5}/>}</div>
+                  </div>
+                ))}
+              </div>
+            </FieldRow>
+
+            {/* ── 친구 초대: 닉네임 풀네임 검색 ───────────── */}
+            <FieldRow
+              label="친구 초대"
+              hint="선택 · 3 / 12명"
+            >
+              <div style={{
+                border: '1.5px solid var(--border-strong)', borderRadius: 12,
+                background: 'var(--surface)', overflow: 'visible',
+              }}>
+                {/* Search input */}
+                <div style={{ position: 'relative', padding: 10, borderBottom: '1px solid var(--border)' }}>
+                  <div style={{
+                    display: 'flex', alignItems: 'center', gap: 10,
+                    padding: '10px 12px', borderRadius: 10,
+                    background: 'var(--surface-2)',
+                  }}>
+                    <Icon name="search" size={15} color="var(--text-muted)"/>
+                    <input
+                      defaultValue="달리는수달"
+                      placeholder="닉네임 풀네임을 정확히 입력하세요"
+                      style={{
+                        flex: 1, border: 'none', outline: 'none', background: 'transparent',
+                        fontSize: 14, fontWeight: 600, color: 'var(--text)',
+                        fontFamily: 'inherit',
+                      }}
+                    />
+                    <span style={{
+                      fontSize: 11, color: 'var(--text-dim)', fontFamily: 'Geist',
+                      padding: '2px 7px', borderRadius: 6, background: 'var(--surface)',
+                      border: '1px solid var(--border)',
+                    }}>Enter</span>
+                  </div>
+                  <div style={{ fontSize: 11, color: 'var(--text-dim)', marginTop: 8, paddingLeft: 4, lineHeight: 1.5 }}>
+                    오타나 부분 일치는 검색되지 않아요. 닉네임은 대소문자를 구분해요.
+                  </div>
+                </div>
+
+                {/* Search result — exact match found */}
+                <div style={{ padding: '8px 10px', borderBottom: '1px solid var(--border)' }}>
+                  <div style={{
+                    fontSize: 10, fontWeight: 700, color: 'var(--text-dim)',
+                    letterSpacing: '.08em', textTransform: 'uppercase',
+                    padding: '4px 6px 6px',
+                  }}>검색 결과 · 1명</div>
+                  {[
+                    { nick: '달리는수달', handle: '@otter_run', avatar: '🦦', color: 'var(--coral-500)', mutual: '함께한 챌린지 2회' },
+                  ].map(u => (
+                    <div key={u.nick} style={{
+                      display: 'flex', alignItems: 'center', gap: 12,
+                      padding: '10px 8px', borderRadius: 10, cursor: 'pointer',
+                      background: 'var(--coral-50)',
+                    }}>
+                      <div style={{
+                        width: 38, height: 38, borderRadius: '50%', flexShrink: 0,
+                        background: u.color, color: 'white',
+                        display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 18,
+                      }}>{u.avatar}</div>
+                      <div style={{ flex: 1, minWidth: 0 }}>
+                        <div style={{ display: 'flex', alignItems: 'baseline', gap: 6 }}>
+                          <span style={{ fontSize: 14, fontWeight: 700, color: 'var(--text)' }}>{u.nick}</span>
+                          <span style={{ fontSize: 11, color: 'var(--text-dim)', fontFamily: 'Geist' }}>{u.handle}</span>
+                        </div>
+                        <div style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 2 }}>{u.mutual}</div>
+                      </div>
+                      <button className="r-btn r-btn--sm" style={{
+                        background: 'var(--coral-500)', color: 'white', fontWeight: 700,
+                        padding: '6px 12px',
+                      }}>
+                        <Icon name="plus" size={12} color="white" strokeWidth={3}/> 초대
+                      </button>
+                    </div>
+                  ))}
+                </div>
+
+                {/* Selected invitees */}
+                <div style={{ padding: '12px 14px' }}>
+                  <div style={{
+                    display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+                    marginBottom: 10,
+                  }}>
+                    <div style={{ fontSize: 12, fontWeight: 700, color: 'var(--text)' }}>
+                      초대할 친구 <span style={{ fontFamily: 'Geist', color: 'var(--coral-600)', marginLeft: 4 }}>3</span>
+                    </div>
+                    <button style={{
+                      border: 'none', background: 'transparent', cursor: 'pointer',
+                      fontSize: 11, color: 'var(--text-muted)', fontWeight: 600,
+                    }}>모두 지우기</button>
+                  </div>
+                  <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+                    {[
+                      { nick: '아침러너_지수', avatar: '🌅', color: 'var(--sunset-500)' },
+                      { nick: '바다보러가자',   avatar: '🌊', color: 'var(--coral-600)' },
+                      { nick: 'morning_kim',  avatar: '☀',  color: 'var(--coral-500)' },
+                    ].map(c => (
+                      <div key={c.nick} style={{
+                        display: 'inline-flex', alignItems: 'center', gap: 8,
+                        padding: '5px 8px 5px 5px', borderRadius: 999,
+                        background: 'var(--surface-2)', border: '1px solid var(--border-strong)',
+                      }}>
+                        <div style={{
+                          width: 22, height: 22, borderRadius: '50%',
+                          background: c.color, color: 'white',
+                          display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 11,
+                        }}>{c.avatar}</div>
+                        <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--text)' }}>{c.nick}</span>
+                        <button style={{
+                          width: 18, height: 18, borderRadius: '50%',
+                          border: 'none', background: 'var(--border-strong)', color: 'var(--text-muted)',
+                          display: 'flex', alignItems: 'center', justifyContent: 'center',
+                          cursor: 'pointer', fontSize: 11, fontWeight: 700,
+                        }}>×</button>
+                      </div>
+                    ))}
+                  </div>
+                  <div style={{
+                    marginTop: 12, padding: '8px 10px', borderRadius: 8,
+                    background: 'var(--surface-2)', display: 'flex', alignItems: 'flex-start', gap: 8,
+                    fontSize: 11, color: 'var(--text-muted)', lineHeight: 1.55,
+                  }}>
+                    <span style={{ fontSize: 12 }}>📨</span>
+                    <span>챌린지를 만들면 초대장이 바로 발송돼요. 수락해야 멤버로 합류돼요.</span>
+                  </div>
+                </div>
+              </div>
+            </FieldRow>
+          </SectionCard>
+
+          {/* ── Section 3: 루틴 설정 ─────────────── */}
+          <SectionCard num={3} title="루틴 설정" sub="이 챌린지에서 함께 수행할 루틴을 정해요">
+            <div style={{
+              padding: '10px 14px', borderRadius: 10, marginBottom: 16,
+              background: 'var(--surface-2)', display: 'flex', alignItems: 'center', gap: 10,
+              fontSize: 12, color: 'var(--text-muted)', lineHeight: 1.5,
+            }}>
+              <span style={{ fontSize: 15 }}>💡</span>
+              <span>챌린지 하나에는 루틴이 <b style={{ color: 'var(--text)' }}>한 개</b>만 들어가요. 카테고리는 위에서 정한 <b style={{ color: 'var(--coral-700)' }}>💪 운동</b>으로 적용돼요.</span>
+            </div>
+
+            <FieldRow label="루틴 이름" required hint="예: 5km 러닝">
+              <input className="r-input" defaultValue="5km 러닝" style={{ fontSize: 15, fontWeight: 600 }}/>
+            </FieldRow>
+
+            <FieldRow label="반복 유형" required>
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 8 }}>
+                {[
+                  { v: 'daily',   label: '매일',     sub: '하루 한 번', on: true },
+                  { v: 'weekly',  label: '매주',     sub: '주 1회 고정' },
+                  { v: 'nweek',   label: '주 N회',   sub: '주마다 N번' },
+                  { v: 'nmonth',  label: '월 N회',   sub: '월마다 N번' },
+                ].map(o => (
+                  <button key={o.v} style={{
+                    padding: '12px 10px', borderRadius: 12,
+                    border: o.on ? '2px solid var(--coral-500)' : '1.5px solid var(--border-strong)',
+                    background: o.on ? 'var(--coral-50)' : 'var(--surface)',
+                    color: o.on ? 'var(--coral-700)' : 'var(--text)',
+                    cursor: 'pointer', textAlign: 'left',
+                  }}>
+                    <div style={{ fontSize: 14, fontWeight: 700 }}>{o.label}</div>
+                    <div style={{ fontSize: 11, color: 'var(--text-dim)', marginTop: 2 }}>{o.sub}</div>
+                  </button>
+                ))}
+              </div>
+            </FieldRow>
+
+            {/* Conditional: repeat count — hidden state demo (commented overlay) */}
+            <FieldRow label="반복 횟수" hint="'주 N회' 또는 '월 N회' 선택 시 표시">
+              <div style={{ position: 'relative' }}>
+                <div className="r-input" style={{
+                  display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+                  fontSize: 14, opacity: 0.45, pointerEvents: 'none',
+                }}>
+                  <span style={{ color: 'var(--text-muted)' }}>주 N회를 선택하면 활성화돼요</span>
+                  <span style={{ fontFamily: 'Geist', fontWeight: 700 }}>—</span>
+                </div>
+              </div>
+            </FieldRow>
+
+            <FieldRow label="선호 수행 시간" hint="선택 · 멤버에게 권장 시간으로 표시돼요">
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 8 }}>
+                {[
+                  { v: 'dawn',    label: '새벽',   sub: '4–7시' },
+                  { v: 'morning', label: '아침',   sub: '7–11시', on: true },
+                  { v: 'noon',    label: '낮',     sub: '11–17시' },
+                  { v: 'evening', label: '저녁',   sub: '17–22시' },
+                  { v: 'night',   label: '밤',     sub: '22–4시' },
+                  { v: 'custom',  label: '직접 입력', sub: '시간 지정' },
+                  { v: 'none',    label: '없음',     sub: '자유롭게' },
+                ].map(o => (
+                  <button key={o.v} style={{
+                    padding: '10px 8px', borderRadius: 10,
+                    border: o.on ? '2px solid var(--coral-500)' : '1.5px solid var(--border-strong)',
+                    background: o.on ? 'var(--coral-50)' : 'var(--surface)',
+                    color: o.on ? 'var(--coral-700)' : 'var(--text)',
+                    cursor: 'pointer', textAlign: 'center',
+                  }}>
+                    <div style={{ fontSize: 13, fontWeight: 700 }}>{o.label}</div>
+                    <div style={{ fontSize: 10, color: 'var(--text-dim)', marginTop: 2, fontFamily: 'Geist' }}>{o.sub}</div>
+                  </button>
+                ))}
+              </div>
+            </FieldRow>
+          </SectionCard>
+        </div>
+
+        {/* Footer CTA */}
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: 28, paddingTop: 24, borderTop: '1px solid var(--border)' }}>
+          <div style={{ fontSize: 12, color: 'var(--text-dim)' }}>
+            필수 항목을 모두 입력하면 만들 수 있어요 <span style={{ color: 'var(--success)', fontWeight: 700, marginLeft: 6 }}>✓ 입력 완료</span>
+          </div>
+          <div style={{ display: 'flex', gap: 10 }}>
+            <button className="r-btn r-btn--ghost" style={{ border: '1px solid var(--border-strong)' }}>임시저장</button>
+            <button className="r-btn r-btn--primary r-btn--lg">
+              <Icon name="check" size={16} color="white" strokeWidth={3}/> 챌린지 만들기
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+// ─── Post-create: private → invite link modal ─────
+const ChallengeCreatedInviteModalArtboard = () => (
+  <div style={{ width: '100%', height: '100%', position: 'relative', background: 'var(--bg)', display: 'flex', flexDirection: 'column' }}>
+    <AppHeader active="challenges" />
+    {/* Dim layer */}
+    <div style={{ flex: 1, opacity: 0.4, padding: '40px 36px' }}>
+      <div style={{ maxWidth: 820, margin: '0 auto' }}>
+        <div style={{ fontSize: 11, color: 'var(--coral-700)', textTransform: 'uppercase', letterSpacing: '.12em', fontWeight: 700 }}>NEW CHALLENGE</div>
+        <h1 style={{ fontSize: 36, fontWeight: 800, letterSpacing: '-0.025em', margin: '6px 0 0' }}>같이 할 사람, 모아볼까요?</h1>
+      </div>
+    </div>
+    <div style={{ position: 'absolute', inset: 0, background: 'rgba(20,18,12,.5)' }}/>
+
+    {/* Centered modal */}
+    <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 24 }}>
+      <div style={{ width: 520, background: 'var(--surface)', borderRadius: 18, boxShadow: '0 30px 80px rgba(0,0,0,.3)', overflow: 'hidden' }}>
+        {/* Hero strip */}
+        <div style={{
+          padding: '28px 28px 22px',
+          background: 'linear-gradient(135deg, var(--coral-500), var(--sunset-500))',
+          color: 'white', position: 'relative', overflow: 'hidden',
+        }}>
+          <div style={{ position: 'absolute', top: -60, right: -40, width: 180, height: 180, borderRadius: '50%', border: '2px solid rgba(255,255,255,.18)' }}/>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12, position: 'relative' }}>
+            <div style={{
+              width: 44, height: 44, borderRadius: '50%',
+              background: 'rgba(255,255,255,.2)',
+              display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 22,
+            }}>🎉</div>
+            <div>
+              <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: '.1em', opacity: 0.9 }}>비공개 챌린지가 만들어졌어요</div>
+              <div style={{ fontSize: 18, fontWeight: 800, marginTop: 2, letterSpacing: '-0.01em' }}>21일 아침 러닝</div>
+            </div>
+          </div>
+          <div style={{ marginTop: 14, fontSize: 13, opacity: 0.95, lineHeight: 1.5, position: 'relative' }}>
+            아래 링크를 보내서 친구들을 초대해보세요. 링크로 들어온 사람만 참여할 수 있어요.
+          </div>
+        </div>
+
+        {/* Body */}
+        <div style={{ padding: 24 }}>
+          <label style={{ ...LABEL, marginBottom: 8 }}>초대 링크</label>
+          <div style={{
+            display: 'flex', gap: 8, alignItems: 'center',
+            padding: '12px 14px', borderRadius: 12,
+            border: '1.5px solid var(--border-strong)', background: 'var(--surface-2)',
+          }}>
+            <span style={{ fontSize: 14, fontFamily: 'Geist', color: 'var(--text)', flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              https://routinely.app/c/k7gM2xa9
+            </span>
+            <button className="r-btn r-btn--sm" style={{ background: 'var(--text)', color: 'var(--surface)' }}>
+              <Icon name="link" size={13} color="white"/> 복사
+            </button>
+          </div>
+
+          {/* Share quick row */}
+          <div style={{ display: 'flex', gap: 8, marginTop: 14 }}>
+            {[
+              { v: 'kakao', label: '카카오톡', emoji: '💬', bg: '#FEE500', color: '#3C1E1E' },
+              { v: 'sms', label: '메시지', emoji: '✉', bg: 'var(--surface-2)', color: 'var(--text)' },
+              { v: 'more', label: '다른 앱', emoji: '⋯', bg: 'var(--surface-2)', color: 'var(--text)' },
+            ].map(s => (
+              <button key={s.v} className="r-btn r-btn--sm" style={{
+                flex: 1, justifyContent: 'center',
+                background: s.bg, color: s.color, fontWeight: 700,
+                border: s.bg === 'var(--surface-2)' ? '1px solid var(--border-strong)' : 'none',
+              }}>
+                <span style={{ marginRight: 4 }}>{s.emoji}</span>{s.label}
+              </button>
+            ))}
+          </div>
+
+          <div style={{
+            marginTop: 18, padding: 12, borderRadius: 10,
+            background: 'var(--surface-2)', display: 'flex', alignItems: 'flex-start', gap: 10,
+            fontSize: 12, color: 'var(--text-muted)', lineHeight: 1.5,
+          }}>
+            <span style={{ fontSize: 14 }}>🔒</span>
+            <span>비공개 챌린지는 검색에 노출되지 않아요. 시작일까지 누구든 링크로 들어올 수 있어요.</span>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div style={{
+          display: 'flex', justifyContent: 'space-between', gap: 8,
+          padding: '14px 24px', background: 'var(--surface-2)', borderTop: '1px solid var(--border)',
+        }}>
+          <button className="r-btn" style={{ background: 'transparent', color: 'var(--text-muted)', border: '1px solid var(--border-strong)' }}>나중에 공유</button>
+          <button className="r-btn r-btn--primary">챌린지로 이동 →</button>
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+Object.assign(window, { ChallengeCreateArtboard, ChallengeCreatedInviteModalArtboard });

--- a/design/v2/artboards-challenge-detail.jsx
+++ b/design/v2/artboards-challenge-detail.jsx
@@ -1,0 +1,605 @@
+// Routinely — Challenge Detail (참여자 전용)
+// State variants: ACTIVE (default), WAITING, ENDED, ACTIVE+ownerMenuOpen, ACTIVE+routineDone, ACTIVE+missed, restDay.
+
+// ─── Shared bits ─────────────────────────────────
+const StatusPill = ({ status }) => {
+  const map = {
+    WAITING: { bg: 'rgba(255,255,255,.22)', label: '대기중', dot: '#fff' },
+    ACTIVE:  { bg: 'rgba(255,255,255,.22)', label: '진행중', dot: '#fff' },
+    ENDED:   { bg: 'rgba(255,255,255,.15)', label: '종료',   dot: 'rgba(255,255,255,.6)' },
+  }[status];
+  return (
+    <span style={{
+      display: 'inline-flex', alignItems: 'center', gap: 5,
+      padding: '4px 11px', borderRadius: 999, background: map.bg, color: 'white',
+      fontSize: 11, fontWeight: 700, letterSpacing: '.04em',
+    }}>
+      <span style={{ width: 5, height: 5, borderRadius: '50%', background: map.dot }}/>
+      {map.label}
+    </span>
+  );
+};
+
+const Dday = ({ status }) => {
+  const map = {
+    WAITING: { num: '7',  label: '시작까지' },
+    ACTIVE:  { num: '8',  label: '종료까지' },
+    ENDED:   { num: null, label: '종료됨' },
+  }[status];
+  return (
+    <div style={{
+      display: 'inline-flex', alignItems: 'baseline', gap: 6,
+      padding: '6px 14px', borderRadius: 999, background: 'rgba(255,255,255,.15)',
+      color: 'white', backdropFilter: 'blur(8px)',
+    }}>
+      {map.num ? <>
+        <span style={{ fontSize: 11, fontWeight: 700, letterSpacing: '.04em', opacity: 0.9 }}>{map.label}</span>
+        <span style={{ fontSize: 18, fontWeight: 800, fontFamily: 'Geist', letterSpacing: '-0.02em' }}>D-{map.num}</span>
+      </> : <>
+        <span style={{ fontSize: 13, fontWeight: 700 }}>· {map.label}</span>
+      </>}
+    </div>
+  );
+};
+
+// ─── Section 1: Hero ──────────────────────────────
+const DetailHero = ({ status, isOwner, ownerMenuOpen }) => (
+  <div style={{ background: 'linear-gradient(135deg, var(--coral-500), var(--sunset-500))', padding: '32px 36px 28px', color: 'white', position: 'relative', overflow: 'hidden' }}>
+    <div style={{ position: 'absolute', top: -100, right: -50, width: 350, height: 350, borderRadius: '50%', border: '2px solid rgba(255,255,255,.15)' }}/>
+    <div style={{ position: 'absolute', bottom: -80, right: 100, width: 200, height: 200, borderRadius: '50%', border: '2px solid rgba(255,255,255,.1)' }}/>
+
+    <div style={{ position: 'relative', display: 'flex', alignItems: 'flex-start', gap: 22 }}>
+      {/* Cover image / emoji */}
+      <div style={{
+        width: 96, height: 96, borderRadius: 22, flexShrink: 0,
+        background: 'rgba(255,255,255,.18)', backdropFilter: 'blur(8px)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 44,
+      }}>🏃</div>
+
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
+          <StatusPill status={status}/>
+          <span style={{
+            display: 'inline-flex', alignItems: 'center', gap: 4,
+            padding: '4px 10px', borderRadius: 999,
+            background: 'rgba(255,255,255,.15)', color: 'white',
+            fontSize: 11, fontWeight: 700, letterSpacing: '.04em',
+          }}>💪 운동</span>
+          {isOwner && (
+            <span style={{
+              padding: '4px 10px', borderRadius: 999,
+              background: 'var(--ink-800)', color: 'white',
+              fontSize: 11, fontWeight: 700, letterSpacing: '.04em',
+            }}>👑 방장</span>
+          )}
+        </div>
+        <h1 style={{ fontSize: 36, fontWeight: 800, letterSpacing: '-0.025em', margin: '12px 0 6px', lineHeight: 1.05 }}>
+          21일 아침 러닝
+        </h1>
+        <p style={{ fontSize: 14, opacity: 0.95, lineHeight: 1.55, maxWidth: 560, margin: 0 }}>
+          매일 아침 5km. 함께 뛰면 외롭지 않아요. 같이 일어나서 한 발 내딛어봐요!
+        </p>
+
+        {/* Meta row */}
+        <div style={{ display: 'flex', gap: 14, marginTop: 18, fontSize: 13, opacity: 0.95, flexWrap: 'wrap', alignItems: 'center' }}>
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontFamily: 'Geist' }}>
+            <Icon name="calendar" size={13} color="white"/>2026.05.27 ~ 06.16
+          </span>
+          <span style={{ width: 3, height: 3, borderRadius: '50%', background: 'rgba(255,255,255,.5)' }}/>
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+            <Icon name="users" size={13} color="white"/>
+            <span style={{ fontFamily: 'Geist' }}>{status === 'ENDED' ? '11/12' : '8/12'}명</span>
+          </span>
+          <span style={{ width: 3, height: 3, borderRadius: '50%', background: 'rgba(255,255,255,.5)' }}/>
+          <Dday status={status}/>
+        </div>
+      </div>
+
+      {/* Right action column */}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8, alignItems: 'flex-end', position: 'relative' }}>
+        <button className="r-btn" style={{ background: 'white', color: 'var(--coral-700)', fontWeight: 700 }}>
+          <Icon name="chat" size={15}/>채팅방 <span style={{ fontSize: 9, fontWeight: 800, padding: '1px 6px', borderRadius: 4, background: 'var(--coral-100)', color: 'var(--coral-700)', marginLeft: 2, letterSpacing: '.08em' }}>v2</span>
+        </button>
+        {isOwner && (
+          <button style={{
+            width: 36, height: 36, borderRadius: 10,
+            background: 'rgba(255,255,255,.15)', backdropFilter: 'blur(8px)',
+            color: 'white', border: 'none', cursor: 'pointer',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            fontSize: 16, fontWeight: 700,
+          }}>⋯</button>
+        )}
+
+        {/* My progress mini chip */}
+        <div style={{
+          marginTop: 4,
+          padding: '8px 14px', borderRadius: 12,
+          background: 'rgba(255,255,255,.18)', backdropFilter: 'blur(8px)',
+          color: 'white', textAlign: 'right',
+        }}>
+          <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '.08em', opacity: 0.85 }}>내 달성률</div>
+          <div style={{ display: 'flex', alignItems: 'baseline', gap: 4, fontFamily: 'Geist' }}>
+            <span style={{ fontSize: 26, fontWeight: 800, letterSpacing: '-0.02em' }}>{status === 'WAITING' ? '—' : status === 'ENDED' ? '78' : '67'}</span>
+            {status !== 'WAITING' && <span style={{ fontSize: 13, fontWeight: 700, opacity: 0.85 }}>%</span>}
+          </div>
+        </div>
+
+        {/* Owner dropdown (when open) */}
+        {isOwner && ownerMenuOpen && (
+          <div style={{
+            position: 'absolute', top: '100%', right: 0, marginTop: 6,
+            width: 240, background: 'var(--surface)', color: 'var(--text)',
+            border: '1px solid var(--border)', borderRadius: 14,
+            boxShadow: '0 20px 50px rgba(0,0,0,.25)', overflow: 'hidden',
+            zIndex: 5,
+          }}>
+            <div style={{ padding: 4 }}>
+              {[
+                { icon: '✏️', label: '챌린지 정보 수정', sub: '대기중일 때만', disabled: status !== 'WAITING' },
+                { icon: '🔗', label: '초대 링크 보기', sub: '비공개 챌린지', disabled: false },
+                { icon: '👥', label: '멤버 관리', sub: '강퇴 가능', disabled: status === 'ENDED' },
+                { icon: '🛑', label: '챌린지 조기 종료', sub: '되돌릴 수 없음', disabled: status === 'ENDED' },
+              ].map((m, i) => (
+                <div key={i} style={{
+                  display: 'flex', alignItems: 'center', gap: 10,
+                  padding: '10px 12px', borderRadius: 9,
+                  fontSize: 13, fontWeight: 600,
+                  color: m.disabled ? 'var(--text-dim)' : 'var(--text)',
+                  cursor: m.disabled ? 'not-allowed' : 'pointer',
+                  opacity: m.disabled ? 0.55 : 1,
+                }}>
+                  <span style={{ fontSize: 14 }}>{m.icon}</span>
+                  <div style={{ flex: 1 }}>
+                    <div>{m.label}</div>
+                    <div style={{ fontSize: 10, color: 'var(--text-dim)', marginTop: 1 }}>{m.sub}</div>
+                  </div>
+                </div>
+              ))}
+              <div style={{ height: 1, background: 'var(--border)', margin: '4px 0' }}/>
+              <div style={{
+                display: 'flex', alignItems: 'center', gap: 10,
+                padding: '10px 12px', borderRadius: 9,
+                fontSize: 13, fontWeight: 600, color: 'var(--coral-700)', cursor: 'pointer',
+              }}>
+                <span style={{ fontSize: 14 }}>🗑</span>
+                <div style={{ flex: 1 }}>
+                  <div>챌린지 삭제</div>
+                  <div style={{ fontSize: 10, color: 'var(--text-dim)', marginTop: 1 }}>본인만 남았을 때만</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  </div>
+);
+
+// ─── Today's routine card variants ───────────────
+const TodayRoutineCard = ({ state }) => {
+  // state: waiting | pending | done | missed | rest | ended
+  const wrap = {
+    background: 'var(--surface)', border: '1px solid var(--border)',
+    borderRadius: 18, padding: 22,
+  };
+  if (state === 'waiting') return (
+    <div style={wrap}>
+      <SectionLabel/>
+      <div style={{ textAlign: 'center', padding: '20px 0 6px' }}>
+        <div style={{ fontSize: 38 }}>📅</div>
+        <div style={{ fontSize: 20, fontWeight: 800, letterSpacing: '-0.01em', marginTop: 12 }}>2026.05.27<span style={{ color: 'var(--text-muted)', marginLeft: 6, fontSize: 14, fontWeight: 600 }}>(수)</span></div>
+        <div style={{ fontSize: 14, color: 'var(--text-muted)', marginTop: 6 }}>시작 예정 · 7일 남음</div>
+      </div>
+      <div style={{ padding: 14, marginTop: 12, borderRadius: 12, background: 'var(--surface-2)', display: 'flex', alignItems: 'center', gap: 10, fontSize: 12, color: 'var(--text-muted)', lineHeight: 1.5 }}>
+        <span style={{ fontSize: 15 }}>🌱</span>
+        <span>시작일 전까지는 멤버를 모으는 시간이에요. 시작되면 매일 인증이 활성화됩니다.</span>
+      </div>
+    </div>
+  );
+
+  if (state === 'rest') return (
+    <div style={wrap}>
+      <SectionLabel/>
+      <div style={{ textAlign: 'center', padding: '20px 0 6px' }}>
+        <div style={{ fontSize: 38 }}>😌</div>
+        <div style={{ fontSize: 20, fontWeight: 800, letterSpacing: '-0.01em', marginTop: 12 }}>오늘은 휴식일</div>
+        <div style={{ fontSize: 13, color: 'var(--text-muted)', marginTop: 6 }}>이 챌린지에서는 화·일요일이 휴식일이에요</div>
+      </div>
+    </div>
+  );
+
+  if (state === 'missed') return (
+    <div style={wrap}>
+      <SectionLabel/>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 14, padding: '6px 0' }}>
+        <div style={{ width: 56, height: 56, borderRadius: 14, background: 'var(--ink-100)', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 26, color: 'var(--text-dim)' }}>🏃</div>
+        <div style={{ flex: 1 }}>
+          <div style={{ fontSize: 16, fontWeight: 800 }}>5km 러닝</div>
+          <div style={{ fontSize: 12, color: 'var(--text-dim)', marginTop: 2 }}>2026.05.14 (목)</div>
+        </div>
+        <span style={{ fontSize: 11, fontWeight: 800, padding: '5px 11px', borderRadius: 999, background: 'var(--ink-100)', color: 'var(--ink-600)', letterSpacing: '.04em' }}>누락</span>
+      </div>
+      <button className="r-btn" disabled style={{ width: '100%', marginTop: 14, background: 'var(--surface-2)', color: 'var(--text-dim)', cursor: 'not-allowed' }}>
+        지난 날은 인증할 수 없어요
+      </button>
+    </div>
+  );
+
+  if (state === 'done') return (
+    <div style={wrap}>
+      <SectionLabel/>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 14 }}>
+        <div style={{
+          width: 56, height: 56, borderRadius: 14, background: 'linear-gradient(135deg, var(--coral-500), var(--sunset-500))',
+          display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 26, color: 'white',
+        }}>🏃</div>
+        <div style={{ flex: 1 }}>
+          <div style={{ fontSize: 16, fontWeight: 800 }}>5km 러닝</div>
+          <div style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 2 }}>오늘 · 매일</div>
+        </div>
+        <span style={{ fontSize: 11, fontWeight: 800, padding: '5px 11px', borderRadius: 999, background: 'var(--success-bg)', color: 'var(--success)', letterSpacing: '.04em' }}>✓ 완료</span>
+      </div>
+      {/* Proof thumbnail */}
+      <div style={{ marginTop: 14, display: 'flex', gap: 10, alignItems: 'center' }}>
+        <div style={{
+          width: 72, height: 72, borderRadius: 12, flexShrink: 0,
+          background: 'linear-gradient(135deg, #FFD166, var(--coral-500))',
+          position: 'relative', overflow: 'hidden',
+        }}>
+          <div style={{ position: 'absolute', inset: 0, background: 'radial-gradient(circle at 30% 70%, rgba(255,255,255,.4), transparent 60%)' }}/>
+          <div style={{ position: 'absolute', bottom: 4, left: 6, color: 'white', fontSize: 9, fontWeight: 700 }}>📍 한강</div>
+        </div>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontSize: 13, color: 'var(--text)', lineHeight: 1.5 }}>"오늘 한강 노을 진짜 죽이네요. 페이스보다 풍경이 좋아서 천천히 뛰었어요 🌅"</div>
+          <div style={{ fontSize: 11, color: 'var(--text-dim)', marginTop: 4, fontFamily: 'Geist' }}>07:24 인증</div>
+        </div>
+      </div>
+      <div style={{ display: 'flex', gap: 8, marginTop: 14 }}>
+        <button className="r-btn r-btn--ghost r-btn--sm" style={{ flex: 1, border: '1px solid var(--border-strong)', justifyContent: 'center' }}>✏️ 수정</button>
+        <button className="r-btn r-btn--ghost r-btn--sm" style={{ flex: 1, border: '1px solid var(--border-strong)', justifyContent: 'center', color: 'var(--text-muted)' }}>피드 보기 →</button>
+      </div>
+    </div>
+  );
+
+  if (state === 'ended') return (
+    <div style={{ ...wrap, background: 'linear-gradient(135deg, var(--coral-50), var(--surface))' }}>
+      <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: '.1em', textTransform: 'uppercase', color: 'var(--coral-700)' }}>최종 결과</div>
+      <div style={{ marginTop: 14, textAlign: 'center', padding: '14px 0 8px' }}>
+        <div style={{ fontSize: 56, fontWeight: 800, fontFamily: 'Geist', letterSpacing: '-0.04em', color: 'var(--coral-600)', lineHeight: 1 }}>
+          78<span style={{ fontSize: 28 }}>%</span>
+        </div>
+        <div style={{ fontSize: 14, color: 'var(--text-muted)', marginTop: 8, fontWeight: 600 }}>
+          21일 중 16일 인증 · 잘했어요 🎉
+        </div>
+      </div>
+      <div style={{
+        marginTop: 14, padding: '12px 14px', borderRadius: 12,
+        background: 'var(--surface-2)', display: 'flex', alignItems: 'center', gap: 10,
+        fontSize: 12, color: 'var(--text-muted)', lineHeight: 1.5,
+      }}>
+        <span style={{ fontSize: 14 }}>🏆</span>
+        <span>완주 배지를 받았어요. <b style={{ color: 'var(--text)' }}>프로필 → 배지</b>에서 확인할 수 있어요.</span>
+      </div>
+      <div style={{ display: 'flex', gap: 8, marginTop: 14 }}>
+        <button className="r-btn r-btn--ghost r-btn--sm" style={{ flex: 1, border: '1px solid var(--border-strong)', justifyContent: 'center' }}>📊 통계 보기</button>
+        <button className="r-btn r-btn--sm" style={{ flex: 1, background: 'var(--coral-500)', color: 'white', justifyContent: 'center' }}>새 챌린지 시작 →</button>
+      </div>
+    </div>
+  );
+
+  // pending (default)
+  return (
+    <div style={wrap}>
+      <SectionLabel/>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 14 }}>
+        <div style={{
+          width: 56, height: 56, borderRadius: 14, background: 'var(--coral-100)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 26, color: 'var(--coral-700)',
+        }}>🏃</div>
+        <div style={{ flex: 1 }}>
+          <div style={{ fontSize: 16, fontWeight: 800 }}>5km 러닝</div>
+          <div style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 2 }}>오늘 · 매일 · 아침</div>
+        </div>
+        <span style={{ fontSize: 11, fontWeight: 800, padding: '5px 11px', borderRadius: 999, background: 'var(--warning-bg)', color: '#a86a00', letterSpacing: '.04em' }}>아직 인증 전</span>
+      </div>
+      <button className="r-btn r-btn--primary" style={{ width: '100%', marginTop: 16, padding: '13px', borderRadius: 12, justifyContent: 'center' }}>
+        <Icon name="check" size={18} color="white" strokeWidth={3}/> 오늘 인증하기
+      </button>
+      <div style={{ fontSize: 11, color: 'var(--text-dim)', textAlign: 'center', marginTop: 8 }}>
+        매일 23:59 마감 · 사진 한 장이면 충분해요
+      </div>
+    </div>
+  );
+};
+
+const SectionLabel = () => (
+  <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: '.1em', textTransform: 'uppercase', color: 'var(--text-dim)', marginBottom: 14 }}>
+    오늘의 루틴
+  </div>
+);
+
+// ─── Monthly calendar ────────────────────────────
+const MonthlyCalendar = ({ status }) => {
+  // For ACTIVE: today = 21 (May 2026), challenge started May 14
+  // For ENDED: every day shown
+  const today = status === 'ENDED' ? 31 : 21;
+  const startDay = 14; // May 14
+  const dayState = (d) => {
+    if (d < startDay) return null; // before challenge
+    if (d > today) return 'future';
+    if ([14,15,16,17,19,20].includes(d)) return 'done';
+    if ([18].includes(d)) return 'missed';
+    if (d === 21) return 'today';
+    return 'done';
+  };
+
+  return (
+    <div style={{ background: 'var(--surface)', border: '1px solid var(--border)', borderRadius: 18, padding: 22 }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 14 }}>
+        <div>
+          <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: '.1em', textTransform: 'uppercase', color: 'var(--text-dim)' }}>달성 캘린더</div>
+          <div style={{ fontSize: 16, fontWeight: 800, fontFamily: 'Geist', marginTop: 4 }}>2026년 5월</div>
+        </div>
+        <div style={{ display: 'flex', gap: 4 }}>
+          <button style={{ width: 26, height: 26, borderRadius: 7, border: '1px solid var(--border-strong)', background: 'var(--surface)', cursor: 'pointer', fontSize: 11 }}>◀</button>
+          <button style={{ width: 26, height: 26, borderRadius: 7, border: '1px solid var(--border-strong)', background: 'var(--surface)', cursor: 'pointer', fontSize: 11 }}>▶</button>
+        </div>
+      </div>
+      {/* DOW */}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: 4, marginBottom: 6 }}>
+        {['월','화','수','목','금','토','일'].map((d, i) => (
+          <div key={d} style={{ textAlign: 'center', fontSize: 10, fontWeight: 700, color: i >= 5 ? 'var(--coral-600)' : 'var(--text-dim)', letterSpacing: '.04em' }}>{d}</div>
+        ))}
+      </div>
+      {/* Cells — May 1 2026 = 금 */}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: 4 }}>
+        {/* lead: Mon, Tue, Wed, Thu empty before Fri */}
+        {[0,1,2,3].map(i => <div key={'l'+i} style={{ aspectRatio: 1 }}/>)}
+        {Array.from({ length: 31 }, (_, i) => i + 1).map(d => {
+          const s = dayState(d);
+          let bg = 'transparent', color = 'var(--text-dim)', border = '1px solid var(--border)';
+          let extra = null;
+          if (s === 'done')   { bg = 'var(--coral-500)'; color = 'white'; border = 'none'; extra = '✓'; }
+          if (s === 'missed') { bg = '#ffe2e5'; color = 'var(--danger)'; border = 'none'; }
+          if (s === 'today')  { bg = 'transparent'; color = 'var(--coral-600)'; border = '2px solid var(--coral-500)'; }
+          if (s === 'future') { color = 'var(--text-dim)'; }
+          if (s === null)     { color = 'var(--text-dim)'; }
+          return (
+            <div key={d} style={{
+              aspectRatio: 1, borderRadius: 8, background: bg, border,
+              color, fontSize: 12, fontWeight: 700, fontFamily: 'Geist',
+              display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center',
+              opacity: s === null ? 0.4 : 1,
+            }}>
+              <span>{d}</span>
+              {extra && <span style={{ fontSize: 8 }}>{extra}</span>}
+            </div>
+          );
+        })}
+      </div>
+      <div style={{ display: 'flex', gap: 12, marginTop: 14, fontSize: 11, color: 'var(--text-muted)' }}>
+        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5 }}><span style={{ width: 10, height: 10, borderRadius: 3, background: 'var(--coral-500)' }}/>인증</span>
+        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5 }}><span style={{ width: 10, height: 10, borderRadius: 3, background: '#ffe2e5' }}/>누락</span>
+        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5 }}><span style={{ width: 10, height: 10, borderRadius: 3, border: '2px solid var(--coral-500)' }}/>오늘</span>
+      </div>
+    </div>
+  );
+};
+
+// ─── Leaderboard ─────────────────────────────────
+const LeaderboardCard = ({ status }) => {
+  const ended = status === 'ENDED';
+  const rows = [
+    { rank: 1, name: '김루틴', color: '#FFD166', rate: 95, medal: '🥇' },
+    { rank: 2, name: '박루틴', color: '#06D6A0', rate: 92, medal: '🥈' },
+    { rank: 3, name: '최루틴', color: '#9D4EDD', rate: 88, medal: '🥉' },
+  ];
+  return (
+    <div style={{ background: 'var(--surface)', border: '1px solid var(--border)', borderRadius: 18, padding: 22, display: 'flex', flexDirection: 'column', width: '100%' }}>
+      <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: '.1em', textTransform: 'uppercase', color: 'var(--text-dim)', marginBottom: 14 }}>
+        {ended ? '최종 순위' : '리더보드'}
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column' }}>
+        {rows.map((p, i) => (
+          <div key={p.rank} style={{
+            display: 'flex', alignItems: 'center', gap: 12,
+            padding: '10px 4px',
+            borderBottom: i < rows.length - 1 ? '1px solid var(--border)' : 'none',
+          }}>
+            <div style={{ width: 22, textAlign: 'center', fontSize: p.medal ? 18 : 13, fontWeight: 700, fontFamily: 'Geist', color: 'var(--text-muted)' }}>
+              {p.medal || p.rank}
+            </div>
+            <Avatar name={p.name[0]} color={p.color} size={32}/>
+            <div style={{ flex: 1, fontSize: 14, fontWeight: 600 }}>{p.name}</div>
+            <div style={{ width: 60, height: 5, background: 'var(--ink-100)', borderRadius: 3, overflow: 'hidden' }}>
+              <div style={{ width: `${p.rate}%`, height: '100%', background: 'var(--coral-500)' }}/>
+            </div>
+            <div style={{ fontSize: 14, fontWeight: 700, fontFamily: 'Geist', width: 36, textAlign: 'right' }}>{p.rate}%</div>
+          </div>
+        ))}
+      </div>
+
+      {/* Gap with dots indicating omitted ranks */}
+      <div style={{
+        flex: 1,
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        gap: 5, padding: '20px 0', minHeight: 28,
+      }}>
+        {[0,1,2].map(i => <span key={i} style={{ width: 4, height: 4, borderRadius: 2, background: 'var(--ink-200)' }}/>)}
+      </div>
+
+      {/* Sticky bottom: my rank */}
+      <div style={{
+        marginTop: 8, padding: '12px 12px',
+        borderRadius: 12, background: 'var(--coral-50)',
+        border: '2px solid var(--coral-500)',
+        display: 'flex', alignItems: 'center', gap: 12,
+      }}>
+        <div style={{ width: 22, textAlign: 'center', fontSize: 13, fontWeight: 800, fontFamily: 'Geist', color: 'var(--coral-700)' }}>12</div>
+        <Avatar name="지" color="#FF8A65" size={32} ring/>
+        <div style={{ flex: 1, fontSize: 14, fontWeight: 700 }}>
+          나 <span style={{ fontSize: 10, fontWeight: 700, color: 'var(--coral-700)', marginLeft: 6, letterSpacing: '.06em' }}>YOU</span>
+        </div>
+        <div style={{ width: 60, height: 5, background: 'rgba(255,255,255,.6)', borderRadius: 3, overflow: 'hidden' }}>
+          <div style={{ width: `${ended ? 78 : 67}%`, height: '100%', background: 'var(--coral-500)' }}/>
+        </div>
+        <div style={{ fontSize: 14, fontWeight: 800, fontFamily: 'Geist', width: 36, textAlign: 'right', color: 'var(--coral-700)' }}>{ended ? 78 : 67}%</div>
+      </div>
+    </div>
+  );
+};
+
+// ─── Feed ────────────────────────────────────────
+const ChallengeFeed = ({ disabled }) => (
+  <section style={{ marginTop: 32, maxWidth: 880, marginLeft: 'auto', marginRight: 'auto' }}>
+    <div style={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between', marginBottom: 18 }}>
+      <div>
+        <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: '.1em', textTransform: 'uppercase', color: 'var(--text-dim)' }}>챌린지 피드</div>
+        <h3 style={{ fontSize: 20, fontWeight: 800, letterSpacing: '-0.015em', margin: '4px 0 0' }}>멤버들의 오늘</h3>
+      </div>
+      <div style={{ display: 'flex', gap: 4, padding: 4, background: 'var(--surface)', border: '1px solid var(--border)', borderRadius: 999 }}>
+        {['최신순', '인기순'].map((t, i) => (
+          <span key={t} style={{ padding: '5px 12px', borderRadius: 999, fontSize: 12, fontWeight: 600, cursor: 'pointer', background: i === 0 ? 'var(--text)' : 'transparent', color: i === 0 ? 'var(--surface)' : 'var(--text-muted)' }}>{t}</span>
+        ))}
+      </div>
+    </div>
+
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      {[
+        { name: '민지', color: '#FFD166', time: '12분 전', text: '오늘 한강 노을 진짜 죽이네요. 페이스보다 풍경이 좋아서 천천히 뛰었어요 🌅 5.2km · 26분, 평균 페이스 5\'00".', distance: '5.2km · 26분', img: 'linear-gradient(135deg, #FFD166, var(--coral-500))', loc: '한강공원', reactions: { '🔥': 12, '💪': 5, '🌅': 3 } },
+        { name: '준호', color: '#06D6A0', time: '24분 전', text: '5km · 28분. 컨디션 좋음. 다들 어제 푹 쉬셨나봐요 페이스 빨라진 느낌 ㅎㅎ', distance: '5.0km · 28분', img: 'linear-gradient(135deg, #06D6A0, #06A67D)', loc: '집 앞 공원', reactions: { '🔥': 6, '💪': 2 } },
+        { name: '다은', color: '#9D4EDD', time: '38분 전', text: '비 와서 짧게만 뛰고 들어왔어요. 그래도 안 빼먹은 거에 의미를 두자고…', distance: '3.0km · 18분', img: 'linear-gradient(135deg, #9D4EDD, #5D4EDD)', loc: '동네 한 바퀴', reactions: { '👏': 4, '🌧': 2 } },
+      ].map((p, i) => (
+        <article key={i} className="r-card" style={{
+          padding: 0, overflow: 'hidden',
+          display: 'grid', gridTemplateColumns: '1fr 1fr',
+          opacity: disabled ? 0.6 : 1,
+        }}>
+          {/* Left: image */}
+          <div style={{ position: 'relative', background: p.img, minHeight: 280 }}>
+            <div style={{ position: 'absolute', inset: 0, background: 'radial-gradient(circle at 30% 70%, rgba(255,255,255,.32), transparent 60%)' }}/>
+            {/* Location pill */}
+            <div style={{
+              position: 'absolute', top: 14, left: 14,
+              display: 'inline-flex', alignItems: 'center', gap: 5,
+              padding: '4px 10px', borderRadius: 999,
+              background: 'rgba(20,18,12,.45)', backdropFilter: 'blur(8px)',
+              color: 'white', fontSize: 11, fontWeight: 700, letterSpacing: '.04em',
+            }}>📍 {p.loc}</div>
+            {/* Distance bottom-right */}
+            <div style={{
+              position: 'absolute', bottom: 14, right: 14,
+              padding: '5px 11px', borderRadius: 8,
+              background: 'rgba(255,255,255,.95)', color: 'var(--coral-700)',
+              fontSize: 12, fontWeight: 800, fontFamily: 'Geist', letterSpacing: '-0.01em',
+            }}>{p.distance}</div>
+          </div>
+
+          {/* Right: text + reactions */}
+          <div style={{ padding: 22, display: 'flex', flexDirection: 'column' }}>
+            {/* Header */}
+            <header style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 14 }}>
+              <Avatar name={p.name[0]} color={p.color} size={36}/>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ fontSize: 14, fontWeight: 700 }}>{p.name}</div>
+                <div style={{ fontSize: 11, color: 'var(--text-dim)' }}>{p.time}</div>
+              </div>
+              <button style={{
+                width: 28, height: 28, borderRadius: 8, border: 'none',
+                background: 'transparent', color: 'var(--text-dim)',
+                cursor: 'pointer', fontSize: 16, lineHeight: 1, fontWeight: 700,
+              }}>⋯</button>
+            </header>
+
+            {/* Body */}
+            <p style={{
+              fontSize: 14, lineHeight: 1.6, color: 'var(--text)',
+              margin: 0, flex: 1,
+            }}>{p.text}</p>
+
+            {/* Reactions */}
+            <footer style={{
+              display: 'flex', alignItems: 'center', gap: 6,
+              marginTop: 16, paddingTop: 14, borderTop: '1px solid var(--border)',
+              flexWrap: 'wrap',
+            }}>
+              {Object.entries(p.reactions).map(([e, n]) => (
+                <span key={e} style={{
+                  padding: '4px 10px', background: 'var(--surface-2)',
+                  border: '1px solid var(--border)', borderRadius: 999,
+                  fontSize: 13, fontWeight: 600,
+                  display: 'inline-flex', alignItems: 'center', gap: 5,
+                }}>
+                  <span>{e}</span><span style={{ fontFamily: 'Geist', color: 'var(--text-muted)' }}>{n}</span>
+                </span>
+              ))}
+              {!disabled && (
+                <span style={{
+                  width: 30, height: 30, borderRadius: '50%',
+                  border: '1.5px dashed var(--border-strong)',
+                  display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+                  fontSize: 14, color: 'var(--text-muted)', cursor: 'pointer',
+                }}>+</span>
+              )}
+              <div style={{ flex: 1 }}/>
+              <button className="r-btn r-btn--ghost r-btn--sm" style={{ color: 'var(--text-muted)', padding: '5px 10px' }}>
+                <Icon name="chat" size={13} color="currentColor"/>댓글 3
+              </button>
+            </footer>
+          </div>
+        </article>
+      ))}
+    </div>
+
+    {!disabled && (
+      <div style={{ display: 'flex', justifyContent: 'center', marginTop: 24 }}>
+        <button className="r-btn r-btn--ghost" style={{ border: '1px solid var(--border-strong)', color: 'var(--text-muted)' }}>더 보기</button>
+      </div>
+    )}
+  </section>
+);
+
+// ─── Composable detail screen ────────────────────
+const ChallengeDetail = ({ status = 'ACTIVE', routineState = 'pending', isOwner = false, ownerMenuOpen = false }) => (
+  <div style={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column', background: 'var(--bg)' }}>
+    <AppHeader active="challenges"/>
+    <div style={{ flex: 1, overflow: 'auto' }}>
+      <DetailHero status={status} isOwner={isOwner} ownerMenuOpen={ownerMenuOpen}/>
+
+      <div style={{ padding: '24px 36px 36px' }}>
+        {/* Section 2 — split. Left: routine card + leaderboard. Right: calendar. */}
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 20 }}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+            <TodayRoutineCard state={status === 'ENDED' ? 'ended' : status === 'WAITING' ? 'waiting' : routineState}/>
+            <div style={{ flex: 1, display: 'flex' }}>
+              <LeaderboardCard status={status}/>
+            </div>
+          </div>
+          <MonthlyCalendar status={status}/>
+        </div>
+
+        {/* Section 3 — feed */}
+        <ChallengeFeed disabled={status === 'ENDED' || status === 'WAITING'}/>
+      </div>
+    </div>
+  </div>
+);
+
+// ─── Public exported variants ────────────────────
+const ChallengeDetailArtboard          = () => <ChallengeDetail status="ACTIVE" routineState="pending"/>;
+const ChallengeDetailWaitingArtboard   = () => <ChallengeDetail status="WAITING"/>;
+const ChallengeDetailDoneArtboard      = () => <ChallengeDetail status="ACTIVE" routineState="done"/>;
+const ChallengeDetailRestArtboard      = () => <ChallengeDetail status="ACTIVE" routineState="rest"/>;
+const ChallengeDetailMissedArtboard    = () => <ChallengeDetail status="ACTIVE" routineState="missed"/>;
+const ChallengeDetailEndedArtboard     = () => <ChallengeDetail status="ENDED"/>;
+const ChallengeDetailOwnerMenuArtboard = () => <ChallengeDetail status="ACTIVE" routineState="pending" isOwner ownerMenuOpen/>;
+
+Object.assign(window, {
+  ChallengeDetailArtboard,
+  ChallengeDetailWaitingArtboard,
+  ChallengeDetailDoneArtboard,
+  ChallengeDetailRestArtboard,
+  ChallengeDetailMissedArtboard,
+  ChallengeDetailEndedArtboard,
+  ChallengeDetailOwnerMenuArtboard,
+});

--- a/design/v2/artboards-challenge-edit.jsx
+++ b/design/v2/artboards-challenge-edit.jsx
@@ -1,0 +1,271 @@
+// Routinely — Challenge Edit modal (owner, WAITING only)
+// Constraints:
+//  • 챌린지: 제목, 소개, 공개여부(비공개→공개만), 최대 인원(현재 멤버 수 이상), 시작일(늦추기만), 종료일(늘리기만)
+//  • 루틴: 제목, 선호 수행 시간만
+
+const ChallengeEditModalArtboard = () => {
+  const STATE = {
+    initial: { title: '21일 아침 러닝', desc: '매일 아침 5km. 함께 뛰면 외롭지 않아요. 같이 일어나서 한 발 내딛어봐요!', visibility: 'private', maxMembers: 12, currentMembers: 8, start: '2026.05.27', end: '2026.06.16', routineName: '5km 러닝', preferredTime: 'morning' },
+  };
+
+  return (
+    <div style={{ width: '100%', height: '100%', position: 'relative', background: 'var(--bg)', display: 'flex', flexDirection: 'column' }}>
+      <AppHeader active="challenges" />
+      {/* Dimmed background — challenge detail abstract */}
+      <div style={{ flex: 1, opacity: 0.35, padding: 36, overflow: 'hidden' }}>
+        <div style={{ height: 220, borderRadius: 18, background: 'linear-gradient(135deg, var(--coral-500), var(--sunset-500))' }}/>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 18, marginTop: 18 }}>
+          <div className="r-card" style={{ height: 220 }}/>
+          <div className="r-card" style={{ height: 220 }}/>
+        </div>
+      </div>
+      <div style={{ position: 'absolute', inset: 0, background: 'rgba(20,18,12,.5)' }}/>
+
+      {/* Modal */}
+      <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 32 }}>
+        <div style={{
+          width: 640, maxHeight: '92%',
+          background: 'var(--surface)', borderRadius: 18,
+          boxShadow: '0 30px 80px rgba(0,0,0,.3)',
+          overflow: 'hidden', display: 'flex', flexDirection: 'column',
+        }}>
+          {/* Header */}
+          <div style={{
+            display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between',
+            padding: '20px 24px 18px', borderBottom: '1px solid var(--border)',
+          }}>
+            <div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <h3 style={{ fontSize: 18, fontWeight: 800, letterSpacing: '-0.015em', margin: 0 }}>챌린지 정보 수정</h3>
+                <span style={{ fontSize: 10, fontWeight: 800, letterSpacing: '.08em', padding: '3px 8px', borderRadius: 5, background: 'var(--ink-800)', color: 'white' }}>👑 방장</span>
+              </div>
+              <div style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 4 }}>
+                <span style={{ display: 'inline-flex', alignItems: 'center', gap: 5, padding: '2px 8px', borderRadius: 6, background: 'var(--surface-2)', color: 'var(--text-muted)', fontSize: 11, fontWeight: 700, marginRight: 6 }}>● 대기중</span>
+                시작 전이어야 수정할 수 있어요
+              </div>
+            </div>
+            <button style={{ background: 'transparent', border: 'none', fontSize: 20, color: 'var(--text-muted)', cursor: 'pointer', lineHeight: 1 }}>×</button>
+          </div>
+
+          {/* Notice */}
+          <div style={{
+            padding: '12px 24px', background: 'var(--coral-50)',
+            display: 'flex', alignItems: 'flex-start', gap: 10,
+            fontSize: 12, color: 'var(--coral-700)', lineHeight: 1.5,
+            borderBottom: '1px solid var(--border)',
+          }}>
+            <span style={{ fontSize: 14 }}>ℹ️</span>
+            <span>
+              일부 항목은 <b>되돌릴 수 없는 방향으로만</b> 수정할 수 있어요 — 공개로만, 인원 늘리기만, 시작일 늦추기만, 종료일 늘리기만.
+            </span>
+          </div>
+
+          {/* Body */}
+          <div style={{ flex: 1, overflow: 'auto', padding: '20px 24px' }}>
+            {/* === 챌린지 정보 === */}
+            <SubHeader title="챌린지 정보"/>
+
+            <EditField label="챌린지 이름" hint="자유 변경">
+              <input className="r-input" defaultValue={STATE.initial.title} style={{ fontSize: 14, fontWeight: 600 }} maxLength={100}/>
+            </EditField>
+
+            <EditField label="챌린지 소개" hint="자유 변경 · 200자">
+              <textarea className="r-input" rows={2} defaultValue={STATE.initial.desc} style={{ resize: 'none', fontFamily: 'inherit', fontSize: 13, lineHeight: 1.5 }}/>
+            </EditField>
+
+            <EditField label="공개 여부" hint="비공개 → 공개로만">
+              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
+                <RadioCard icon="🔒" label="비공개" sub="현재 설정 · 변경 불가" disabled current/>
+                <RadioCard icon="🌍" label="공개" sub="공개 목록에 노출돼요" arrow/>
+              </div>
+              <div style={{ fontSize: 11, color: 'var(--text-dim)', marginTop: 6 }}>한번 공개로 바꾸면 다시 비공개로 되돌릴 수 없어요</div>
+            </EditField>
+
+            <EditField label="최대 참여 인원" hint={`현재 ${STATE.initial.currentMembers}명 · ${STATE.initial.currentMembers}명 이상으로만`}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+                <input type="range" min={STATE.initial.currentMembers} max="50" defaultValue={STATE.initial.maxMembers} style={{ flex: 1, accentColor: 'var(--coral-500)' }}/>
+                <div style={{ minWidth: 88, textAlign: 'right' }}>
+                  <span style={{ fontSize: 20, fontWeight: 800, fontFamily: 'Geist', color: 'var(--coral-600)' }}>12</span>
+                  <span style={{ fontSize: 11, color: 'var(--text-muted)', marginLeft: 3, fontWeight: 600 }}>명</span>
+                </div>
+              </div>
+              {/* Tick markers */}
+              <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 10, color: 'var(--text-dim)', fontFamily: 'Geist', marginTop: 4 }}>
+                <span style={{ color: 'var(--ink-300)' }}>8 (현재)</span>
+                <span style={{ color: 'var(--coral-600)', fontWeight: 700 }}>12 (지금)</span>
+                <span>50</span>
+              </div>
+            </EditField>
+
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 14 }}>
+              <EditField label="시작일" hint="늦추기만">
+                <div className="r-input" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', cursor: 'pointer', fontSize: 13 }}>
+                  <span style={{ fontFamily: 'Geist', fontWeight: 600 }}>2026.05.30 (토)</span>
+                  <Icon name="calendar" size={14} color="var(--text-muted)"/>
+                </div>
+                <div style={{ fontSize: 11, color: 'var(--text-dim)', marginTop: 4 }}>원래 5.27 → <b style={{ color: 'var(--text)' }}>5.30</b> · +3일 늦춤</div>
+              </EditField>
+              <EditField label="종료일" hint="늘리기만">
+                <div className="r-input" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', cursor: 'pointer', fontSize: 13 }}>
+                  <span style={{ fontFamily: 'Geist', fontWeight: 600 }}>2026.06.20 (토)</span>
+                  <Icon name="calendar" size={14} color="var(--text-muted)"/>
+                </div>
+                <div style={{ fontSize: 11, color: 'var(--text-dim)', marginTop: 4 }}>원래 6.16 → <b style={{ color: 'var(--text)' }}>6.20</b> · +4일 늘림</div>
+              </EditField>
+            </div>
+
+            {/* === 루틴 정보 === */}
+            <div style={{ height: 1, background: 'var(--border)', margin: '22px 0 18px' }}/>
+            <SubHeader title="루틴 정보" sub="이 챌린지의 단일 루틴 · 일부만 수정 가능"/>
+
+            <EditField label="루틴 이름" hint="자유 변경">
+              <input className="r-input" defaultValue={STATE.initial.routineName} style={{ fontSize: 14, fontWeight: 600 }}/>
+            </EditField>
+
+            <EditField label="선호 수행 시간" hint="자유 변경">
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 6 }}>
+                {[
+                  { v: 'dawn',    label: '새벽', sub: '4–7시' },
+                  { v: 'morning', label: '아침', sub: '7–11시', on: true },
+                  { v: 'noon',    label: '낮',   sub: '11–17시' },
+                  { v: 'evening', label: '저녁', sub: '17–22시' },
+                  { v: 'night',   label: '밤',   sub: '22–4시' },
+                  { v: 'custom',  label: '직접', sub: '시간 지정' },
+                  { v: 'none',    label: '없음', sub: '자유' },
+                ].map(o => (
+                  <button key={o.v} style={{
+                    padding: '10px 6px', borderRadius: 10,
+                    border: o.on ? '2px solid var(--coral-500)' : '1.5px solid var(--border-strong)',
+                    background: o.on ? 'var(--coral-50)' : 'var(--surface)',
+                    color: o.on ? 'var(--coral-700)' : 'var(--text)',
+                    cursor: 'pointer', textAlign: 'center',
+                  }}>
+                    <div style={{ fontSize: 12, fontWeight: 700 }}>{o.label}</div>
+                    <div style={{ fontSize: 10, color: 'var(--text-dim)', marginTop: 2, fontFamily: 'Geist' }}>{o.sub}</div>
+                  </button>
+                ))}
+              </div>
+            </EditField>
+
+            {/* === Locked fields (read-only) === */}
+            <div style={{ marginTop: 22, padding: 14, borderRadius: 12, background: 'var(--surface-2)' }}>
+              <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: '.08em', textTransform: 'uppercase', color: 'var(--text-dim)', marginBottom: 10 }}>🔒 수정할 수 없는 항목</div>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+                {[
+                  ['카테고리', '💪 운동'],
+                  ['반복 유형', '매일'],
+                  ['대표 이미지', '🏃'],
+                  ['공개 → 비공개', '불가능'],
+                  ['인원 줄이기', '불가능'],
+                  ['시작일 앞당기기', '불가능'],
+                  ['종료일 앞당기기', '불가능'],
+                ].map(([k, v]) => (
+                  <div key={k} style={{ display: 'inline-flex', alignItems: 'center', gap: 6, padding: '5px 10px', borderRadius: 999, background: 'var(--surface)', border: '1px solid var(--border)', fontSize: 11 }}>
+                    <span style={{ color: 'var(--text-dim)' }}>{k}</span>
+                    <span style={{ fontWeight: 600, color: 'var(--text-muted)' }}>· {v}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {/* Footer */}
+          <div style={{
+            display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 10,
+            padding: '16px 24px', background: 'var(--surface-2)', borderTop: '1px solid var(--border)',
+          }}>
+            <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>
+              <b style={{ color: 'var(--success)' }}>5개 변경</b> · 저장하면 멤버들에게 알림이 가요
+            </div>
+            <div style={{ display: 'flex', gap: 8 }}>
+              <button className="r-btn" style={{ background: 'transparent', color: 'var(--text-muted)', border: '1px solid var(--border-strong)' }}>취소</button>
+              <button className="r-btn r-btn--primary">변경사항 저장</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ─── State 2: ACTIVE / ENDED — edit disabled state ──
+const ChallengeEditLockedArtboard = () => (
+  <div style={{ width: '100%', height: '100%', position: 'relative', background: 'var(--bg)', display: 'flex', flexDirection: 'column' }}>
+    <AppHeader active="challenges" />
+    <div style={{ flex: 1, opacity: 0.35, padding: 36 }}>
+      <div style={{ height: 220, borderRadius: 18, background: 'linear-gradient(135deg, var(--coral-500), var(--sunset-500))' }}/>
+    </div>
+    <div style={{ position: 'absolute', inset: 0, background: 'rgba(20,18,12,.5)' }}/>
+
+    <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 32 }}>
+      <div style={{
+        width: 460, background: 'var(--surface)',
+        borderRadius: 18, boxShadow: '0 30px 80px rgba(0,0,0,.3)',
+        overflow: 'hidden',
+      }}>
+        <div style={{ padding: 32, textAlign: 'center' }}>
+          <div style={{ fontSize: 44, marginBottom: 14 }}>🔒</div>
+          <div style={{ fontSize: 20, fontWeight: 800, letterSpacing: '-0.015em' }}>지금은 수정할 수 없어요</div>
+          <p style={{ fontSize: 13, color: 'var(--text-muted)', marginTop: 10, lineHeight: 1.55 }}>
+            챌린지 정보 수정은 <b style={{ color: 'var(--text)' }}>대기중</b>일 때만 가능해요.<br/>
+            이미 시작된 챌린지는 멤버 모두에게 영향을 주기 때문에<br/>
+            일정/규칙을 바꿀 수 없도록 잠겨 있어요.
+          </p>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 10, marginTop: 22 }}>
+            <div style={{ padding: '10px 14px', borderRadius: 10, background: 'var(--surface-2)', display: 'flex', alignItems: 'center', gap: 10, fontSize: 12 }}>
+              <span>📣</span><span style={{ color: 'var(--text-muted)' }}>대신 채팅방으로 멤버들과 소통해보세요</span>
+            </div>
+            <div style={{ padding: '10px 14px', borderRadius: 10, background: 'var(--surface-2)', display: 'flex', alignItems: 'center', gap: 10, fontSize: 12 }}>
+              <span>🛑</span><span style={{ color: 'var(--text-muted)' }}>꼭 멈춰야 한다면 <b style={{ color: 'var(--coral-700)' }}>조기 종료</b>를 사용하세요</span>
+            </div>
+          </div>
+        </div>
+        <div style={{ padding: '14px 24px', background: 'var(--surface-2)', borderTop: '1px solid var(--border)', display: 'flex', justifyContent: 'flex-end' }}>
+          <button className="r-btn r-btn--primary">확인</button>
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+// ─── shared subcomponents ──────────────────────
+const SubHeader = ({ title, sub }) => (
+  <div style={{ marginBottom: 14 }}>
+    <div style={{ fontSize: 12, fontWeight: 800, letterSpacing: '.06em', textTransform: 'uppercase', color: 'var(--coral-700)' }}>{title}</div>
+    {sub && <div style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 3 }}>{sub}</div>}
+  </div>
+);
+
+const EditField = ({ label, hint, children }) => (
+  <div style={{ marginBottom: 16 }}>
+    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 6 }}>
+      <label style={{ fontSize: 11, fontWeight: 700, color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '.06em' }}>{label}</label>
+      {hint && <span style={{ fontSize: 11, color: 'var(--text-dim)' }}>{hint}</span>}
+    </div>
+    {children}
+  </div>
+);
+
+const RadioCard = ({ icon, label, sub, on, current, disabled, arrow }) => (
+  <div style={{
+    display: 'flex', alignItems: 'center', gap: 10,
+    padding: '11px 13px', borderRadius: 12,
+    border: on ? '2px solid var(--coral-500)' : '1.5px solid var(--border-strong)',
+    background: on ? 'var(--coral-50)' : current ? 'var(--surface-2)' : 'var(--surface)',
+    cursor: disabled ? 'not-allowed' : 'pointer',
+    opacity: disabled && !current ? 0.5 : 1,
+    position: 'relative',
+  }}>
+    <span style={{ fontSize: 18 }}>{icon}</span>
+    <div style={{ flex: 1, minWidth: 0 }}>
+      <div style={{ fontSize: 13, fontWeight: 700, display: 'flex', alignItems: 'center', gap: 5 }}>
+        {label}
+        {current && <span style={{ fontSize: 9, fontWeight: 800, letterSpacing: '.06em', padding: '2px 6px', borderRadius: 4, background: 'var(--ink-800)', color: 'white' }}>현재</span>}
+        {arrow && <span style={{ fontSize: 10, color: 'var(--coral-600)' }}>→ 변경</span>}
+      </div>
+      <div style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 1 }}>{sub}</div>
+    </div>
+  </div>
+);
+
+Object.assign(window, { ChallengeEditModalArtboard, ChallengeEditLockedArtboard });

--- a/design/v2/artboards-routines.jsx
+++ b/design/v2/artboards-routines.jsx
@@ -628,63 +628,436 @@ const ChallengeDetailArtboard = () => (
 );
 
 // ─── Challenge Browse ──────────────────────────
-const ChallengeBrowseArtboard = () => (
-  <div style={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column', background: 'var(--bg)' }}>
-    <AppHeader active="challenges" />
-    <div style={{ flex: 1, overflow: 'auto', padding: '32px 36px' }}>
-      <div style={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between', marginBottom: 20 }}>
-        <div>
-          <div style={{ fontSize: 11, color: 'var(--text-dim)', textTransform: 'uppercase', letterSpacing: '.1em', fontWeight: 700 }}>EXPLORE</div>
-          <h1 style={{ fontSize: 44, fontWeight: 700, letterSpacing: '-0.03em', margin: '4px 0 0' }}>같이 할 사람,<br/>찾고 있어요?</h1>
+// Two tabs: 내 챌린지 / 공개 챌린지.
+// Implemented as a parameterized component so each artboard renders one tab.
+
+const ChallengeBrowseHeader = ({ tab, setTab, query }) => (
+  <>
+    <div style={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between', marginBottom: 18 }}>
+      <div>
+        <div style={{ fontSize: 11, color: 'var(--text-dim)', textTransform: 'uppercase', letterSpacing: '.1em', fontWeight: 700 }}>CHALLENGES</div>
+        <h1 style={{ fontSize: 36, fontWeight: 800, letterSpacing: '-0.03em', margin: '4px 0 0', lineHeight: 1.05 }}>같이 만들어가는 꾸준함</h1>
+      </div>
+      <button className="r-btn r-btn--primary"><Icon name="plus" size={16}/>챌린지 만들기</button>
+    </div>
+
+    {/* Tabs */}
+    <div style={{ display: 'flex', gap: 24, borderBottom: '1px solid var(--border)', marginBottom: 18 }}>
+      {[
+        { id: 'mine', label: '내 챌린지', count: 5 },
+        { id: 'public', label: '공개 챌린지', count: 142 },
+      ].map(t => {
+        const on = tab === t.id;
+        return (
+          <button key={t.id} style={{
+            background: 'transparent', border: 'none', cursor: 'pointer',
+            padding: '12px 2px', display: 'inline-flex', alignItems: 'center', gap: 8,
+            fontSize: 15, fontWeight: on ? 700 : 500,
+            color: on ? 'var(--coral-600)' : 'var(--text-muted)',
+            borderBottom: on ? '2.5px solid var(--coral-500)' : '2.5px solid transparent',
+            marginBottom: -1,
+          }}>
+            <span>{t.label}</span>
+            <span style={{
+              fontSize: 11, fontFamily: 'Geist', fontWeight: 700,
+              padding: '2px 7px', borderRadius: 999,
+              background: on ? 'var(--coral-100)' : 'var(--surface-2)',
+              color: on ? 'var(--coral-700)' : 'var(--text-muted)',
+            }}>{t.count}</span>
+          </button>
+        );
+      })}
+    </div>
+
+  </>
+);
+
+const CHIP = (on, color = 'var(--text)') => ({
+  display: 'inline-flex', alignItems: 'center', gap: 6,
+  padding: '7px 13px', borderRadius: 999,
+  border: on ? 'none' : '1.5px solid var(--border-strong)',
+  background: on ? color : 'var(--surface)',
+  color: on ? 'white' : 'var(--text)',
+  fontFamily: 'inherit', fontSize: 13, fontWeight: 600, cursor: 'pointer',
+});
+
+const CATEGORY_CHIPS = [
+  { v: 'all', emoji: '✨', label: '전체' },
+  { v: 'fitness', emoji: '💪', label: '운동' },
+  { v: 'study', emoji: '📚', label: '공부' },
+  { v: 'mind', emoji: '🧘', label: '마음챙김' },
+  { v: 'life', emoji: '🌱', label: '생활' },
+  { v: 'hobby', emoji: '🎨', label: '취미' },
+  { v: 'health', emoji: '💊', label: '건강' },
+];
+
+// Status badge for cards
+const StatusBadge = ({ status }) => {
+  const map = {
+    WAITING: { bg: 'var(--surface-2)', fg: 'var(--text-muted)', dot: 'var(--text-dim)', label: '대기' },
+    ACTIVE:  { bg: 'var(--coral-100)', fg: 'var(--coral-700)', dot: 'var(--coral-500)', label: '진행중' },
+    ENDED:   { bg: 'var(--ink-100)', fg: 'var(--ink-600)', dot: 'var(--ink-400)', label: '종료' },
+  }[status];
+  return (
+    <span style={{
+      display: 'inline-flex', alignItems: 'center', gap: 5,
+      padding: '3px 9px', borderRadius: 999,
+      background: map.bg, color: map.fg,
+      fontSize: 10, fontWeight: 700, letterSpacing: '.04em',
+    }}>
+      <span style={{ width: 5, height: 5, borderRadius: '50%', background: map.dot }}/>
+      {map.label}
+    </span>
+  );
+};
+
+const CategoryBadge = ({ code }) => {
+  const c = CATEGORY_CHIPS.find(x => x.v === code) || CATEGORY_CHIPS[0];
+  return (
+    <span style={{ fontSize: 10, fontWeight: 700, padding: '3px 8px', borderRadius: 6, background: 'var(--surface-2)', color: 'var(--text-muted)' }}>
+      {c.emoji} {c.label}
+    </span>
+  );
+};
+
+const RoleBadge = ({ role }) => (
+  <span style={{
+    display: 'inline-flex', alignItems: 'center', gap: 4,
+    padding: '3px 8px', borderRadius: 6,
+    background: role === 'OWNER' ? 'var(--ink-800)' : 'transparent',
+    color: role === 'OWNER' ? 'white' : 'var(--text-muted)',
+    border: role === 'OWNER' ? 'none' : '1px solid var(--border-strong)',
+    fontSize: 10, fontWeight: 700, letterSpacing: '.04em',
+  }}>
+    {role === 'OWNER' ? '👑 방장' : '멤버'}
+  </span>
+);
+
+// ─── MyChallenges card ─────────────────────────────
+const MyChallengeCard = ({ c }) => {
+  const full = c.current >= c.max;
+  return (
+    <div className="r-card" style={{ padding: 18, display: 'flex', flexDirection: 'column', gap: 12, cursor: 'pointer' }}>
+      <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 8 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, flex: 1, minWidth: 0 }}>
+          <div style={{
+            width: 44, height: 44, borderRadius: 12, flexShrink: 0,
+            background: c.bg, display: 'flex', alignItems: 'center', justifyContent: 'center',
+            fontSize: 22,
+          }}>{c.emoji}</div>
+          <div style={{ minWidth: 0, flex: 1 }}>
+            <div style={{ fontSize: 16, fontWeight: 700, letterSpacing: '-0.01em', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{c.title}</div>
+            <div style={{ display: 'flex', gap: 5, marginTop: 4, alignItems: 'center', flexWrap: 'wrap' }}>
+              <StatusBadge status={c.status}/>
+              <CategoryBadge code={c.category}/>
+              <RoleBadge role={c.role}/>
+            </div>
+          </div>
         </div>
-        <button className="r-btn r-btn--primary"><Icon name="plus" size={16}/>챌린지 만들기</button>
       </div>
 
-      <div style={{ display: 'flex', gap: 10, marginBottom: 24, alignItems: 'center' }}>
-        <div className="r-input" style={{ flex: 1, display: 'flex', alignItems: 'center', gap: 8, padding: '10px 14px' }}>
-          <Icon name="search" size={16} color="var(--text-muted)"/>
-          <input style={{ border: 'none', outline: 'none', background: 'transparent', flex: 1, fontFamily: 'inherit', fontSize: 14 }} placeholder="러닝, 독서, 명상..." defaultValue=""/>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', paddingTop: 10, borderTop: '1px solid var(--border)' }}>
+        <div style={{ fontSize: 12, color: 'var(--text-muted)', fontFamily: 'Geist' }}>
+          {c.startedAt} ~ {c.endedAt}
         </div>
-        <div style={{ display: 'flex', gap: 6 }}>
-          {['전체', '🔥 인기', '🏃 운동', '📚 독서', '🧘 마음', '🌅 모닝'].map((t, i) => (
-            <span key={t} style={{ padding: '8px 14px', borderRadius: 999, fontSize: 13, fontWeight: 600, background: i === 0 ? 'var(--text)' : 'var(--surface)', color: i === 0 ? 'var(--surface)' : 'var(--text)', border: i === 0 ? 'none' : '1px solid var(--border-strong)', cursor: 'pointer' }}>{t}</span>
+        <div style={{ fontSize: 13, fontWeight: 700, fontFamily: 'Geist', color: 'var(--text)' }}>
+          {c.current}<span style={{ color: 'var(--text-dim)', fontWeight: 500 }}>/{c.max}명</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ─── PublicChallenges card ─────────────────────────
+const PublicChallengeCard = ({ c }) => {
+  const full = c.current >= c.max;
+  return (
+    <div className="r-card" style={{ overflow: 'hidden', padding: 0, display: 'flex', flexDirection: 'column', cursor: 'pointer' }}>
+      <div style={{ background: c.bg, padding: '14px 18px 38px', position: 'relative', minHeight: 80 }}>
+        <div style={{ position: 'absolute', top: -40, right: -40, width: 140, height: 140, borderRadius: '50%', border: '1.5px solid rgba(255,255,255,.18)' }}/>
+        <div style={{ position: 'relative', display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between' }}>
+          <StatusBadge status={c.status}/>
+          <span style={{ fontSize: 32 }}>{c.emoji}</span>
+        </div>
+      </div>
+
+      <div style={{ padding: '0 18px 18px', marginTop: -22, flex: 1, display: 'flex', flexDirection: 'column' }}>
+        <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 8, marginBottom: 4 }}>
+          <CategoryBadge code={c.category}/>
+        </div>
+        <div style={{ fontSize: 17, fontWeight: 800, marginTop: 6, letterSpacing: '-0.01em' }}>{c.title}</div>
+        <div style={{
+          fontSize: 12, color: 'var(--text-muted)', lineHeight: 1.45, marginTop: 6,
+          display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical', overflow: 'hidden',
+          minHeight: 34,
+        }}>{c.description}</div>
+
+        <div style={{ fontSize: 11, color: 'var(--text-dim)', marginTop: 10, fontFamily: 'Geist' }}>
+          {c.startedAt} ~ {c.endedAt}
+        </div>
+
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginTop: 12, paddingTop: 12, borderTop: '1px solid var(--border)' }}>
+          <div style={{
+            fontSize: 13, fontWeight: 700, fontFamily: 'Geist',
+            color: full ? 'var(--coral-600)' : 'var(--text)',
+          }}>
+            {full && <span style={{ fontSize: 10, fontWeight: 800, padding: '2px 7px', borderRadius: 5, background: 'var(--coral-100)', color: 'var(--coral-700)', marginRight: 6, letterSpacing: '.04em' }}>마감</span>}
+            {c.current}<span style={{ color: 'var(--text-dim)', fontWeight: 500 }}>/{c.max}명</span>
+          </div>
+          <button className="r-btn r-btn--sm" disabled={full} style={full
+            ? { background: 'var(--surface-2)', color: 'var(--text-dim)', cursor: 'not-allowed' }
+            : { background: 'var(--coral-500)', color: 'white', boxShadow: 'var(--sh-coral)' }}>
+            {full ? '정원 마감' : '참여하기'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ─── Pagination ───────────────────────────────────
+const Pagination = ({ current, total, perPage, totalItems }) => {
+  // Build page-number list with ellipsis: 1 … (c-1) c (c+1) … total
+  const pages = [];
+  const push = (p) => pages.push(p);
+  if (total <= 7) {
+    for (let i = 1; i <= total; i++) push(i);
+  } else {
+    push(1);
+    if (current > 3) push('…L');
+    const start = Math.max(2, current - 1);
+    const end = Math.min(total - 1, current + 1);
+    for (let i = start; i <= end; i++) push(i);
+    if (current < total - 2) push('…R');
+    push(total);
+  }
+  const from = (current - 1) * perPage + 1;
+  const to = Math.min(current * perPage, totalItems);
+
+  const btn = (active, disabled) => ({
+    minWidth: 34, height: 34, padding: '0 10px', borderRadius: 8,
+    border: active ? 'none' : '1px solid var(--border-strong)',
+    background: active ? 'var(--coral-500)' : 'var(--surface)',
+    color: active ? 'white' : (disabled ? 'var(--text-dim)' : 'var(--text)'),
+    fontFamily: 'Geist', fontSize: 13, fontWeight: active ? 800 : 600,
+    cursor: disabled ? 'not-allowed' : 'pointer', opacity: disabled ? 0.5 : 1,
+    display: 'inline-flex', alignItems: 'center', justifyContent: 'center', gap: 4,
+  });
+
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+      gap: 14, marginTop: 28, padding: '18px 4px 4px',
+      borderTop: '1px solid var(--border)',
+      flexWrap: 'wrap',
+    }}>
+      <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>
+        총 <span style={{ fontFamily: 'Geist', fontWeight: 700, color: 'var(--text)' }}>{totalItems}</span>개 ·
+        <span style={{ fontFamily: 'Geist', fontWeight: 600, color: 'var(--text)', marginLeft: 4 }}>{from}–{to}</span> 표시 중
+      </div>
+
+      <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+        <button style={btn(false, current === 1)}>‹ 이전</button>
+        {pages.map((p, i) => (
+          typeof p === 'number'
+            ? <button key={i} style={btn(p === current, false)}>{p}</button>
+            : <span key={i} style={{ minWidth: 22, textAlign: 'center', color: 'var(--text-dim)', fontFamily: 'Geist', fontSize: 13 }}>…</span>
+        ))}
+        <button style={btn(false, current === total)}>다음 ›</button>
+      </div>
+
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <span style={{ fontSize: 11, fontWeight: 700, color: 'var(--text-dim)', letterSpacing: '.06em', textTransform: 'uppercase' }}>페이지당</span>
+        <div style={{ display: 'flex', gap: 0, background: 'var(--surface)', border: '1px solid var(--border-strong)', borderRadius: 8, overflow: 'hidden' }}>
+          {[12, 24, 48].map(n => (
+            <span key={n} style={{
+              padding: '7px 10px', fontSize: 12, fontWeight: 700, fontFamily: 'Geist',
+              cursor: 'pointer',
+              background: n === perPage ? 'var(--text)' : 'transparent',
+              color: n === perPage ? 'var(--surface)' : 'var(--text-muted)',
+            }}>{n}</span>
           ))}
         </div>
       </div>
+    </div>
+  );
+};
 
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 16 }}>
-        {[
-          { name: '21일 아침 러닝', emoji: '🏃', members: 12, days: 21, host: '민지', bg: 'linear-gradient(135deg, var(--coral-500), var(--sunset-500))', joined: true },
-          { name: '하루 한 권 독서', emoji: '📚', members: 8, days: 30, host: '준호', bg: 'linear-gradient(135deg, #118AB2, #06D6A0)' },
-          { name: '저녁 9시 명상', emoji: '🧘', members: 24, days: 14, host: '다은', bg: 'linear-gradient(135deg, #9D4EDD, #5D4EDD)' },
-          { name: '물 2L 마시기', emoji: '💧', members: 16, days: 30, host: '시우', bg: 'linear-gradient(135deg, #06D6A0, #06A67D)' },
-          { name: '주 3회 헬스장', emoji: '💪', members: 6, days: 28, host: '하준', bg: 'linear-gradient(135deg, #EF476F, #C9184A)' },
-          { name: '아침 6시 기상', emoji: '🌅', members: 20, days: 21, host: '서윤', bg: 'linear-gradient(135deg, #FFD166, var(--sunset-500))' },
-        ].map((c, i) => (
-          <div key={i} className="r-card" style={{ overflow: 'hidden', padding: 0 }}>
-            <div style={{ background: c.bg, padding: '20px 18px 60px', position: 'relative', minHeight: 100 }}>
-              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
-                <span className="r-badge" style={{ background: 'rgba(255,255,255,.25)', color: 'white' }}>{c.joined ? '● JOINED' : '● ACTIVE'}</span>
-                <span style={{ fontSize: 38 }}>{c.emoji}</span>
-              </div>
-            </div>
-            <div style={{ padding: '0 18px 18px', marginTop: -32 }}>
-              <AvatarStack items={Array.from({length: 4}).map((_,j) => ({ name: ['지','민','준','다'][j], color: ['#FF8A65','#FFD166','#06D6A0','#9D4EDD'][j] }))} size={32}/>
-              <div style={{ fontSize: 17, fontWeight: 700, marginTop: 12 }}>{c.name}</div>
-              <div style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 4, display: 'flex', gap: 10 }}>
-                <span><Icon name="users" size={11} style={{ verticalAlign: -1, marginRight: 3 }}/>{c.members}명</span>
-                <span><Icon name="calendar" size={11} style={{ verticalAlign: -1, marginRight: 3 }}/>{c.days}일</span>
-              </div>
-              <button className="r-btn r-btn--sm" style={{ marginTop: 14, width: '100%', background: c.joined ? 'var(--surface-2)' : 'var(--coral-500)', color: c.joined ? 'var(--text)' : 'white', boxShadow: c.joined ? 'none' : 'var(--sh-coral)' }}>
-                {c.joined ? '진행중' : '참여하기'}
-              </button>
-            </div>
+// ─── Tab 1: My Challenges ──────────────────────────
+const ChallengeBrowseArtboard = () => {
+  const myList = [
+    { title: '21일 아침 러닝', emoji: '🏃', bg: 'linear-gradient(135deg,var(--coral-500),var(--sunset-500))', category: 'fitness', status: 'ACTIVE', role: 'OWNER', startedAt: '2026.05.06', endedAt: '2026.05.27', current: 8, max: 12 },
+    { title: '하루 한 권 독서', emoji: '📚', bg: 'linear-gradient(135deg,#118AB2,#06D6A0)', category: 'study', status: 'ACTIVE', role: 'MEMBER', startedAt: '2026.05.15', endedAt: '2026.06.14', current: 6, max: 8 },
+    { title: '저녁 9시 명상', emoji: '🧘', bg: 'linear-gradient(135deg,#9D4EDD,#5D4EDD)', category: 'mind', status: 'WAITING', role: 'MEMBER', startedAt: '2026.05.25', endedAt: '2026.06.07', current: 4, max: 20 },
+    { title: '물 2L 마시기', emoji: '💧', bg: 'linear-gradient(135deg,#06D6A0,#06A67D)', category: 'health', status: 'ACTIVE', role: 'MEMBER', startedAt: '2026.05.01', endedAt: '2026.05.30', current: 16, max: 30 },
+    { title: '주 3회 헬스장', emoji: '💪', bg: 'linear-gradient(135deg,#EF476F,#C9184A)', category: 'fitness', status: 'ENDED', role: 'OWNER', startedAt: '2026.04.01', endedAt: '2026.04.28', current: 6, max: 6 },
+  ];
+
+  return (
+    <div style={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column', background: 'var(--bg)' }}>
+      <AppHeader active="challenges" />
+      <div style={{ flex: 1, overflow: 'auto', padding: '28px 36px' }}>
+        <ChallengeBrowseHeader tab="mine" query="tab=mine&category=all&status=active&sort=joinedAt"/>
+
+        {/* Filter row 1 — search + sort */}
+        <div style={{ display: 'flex', gap: 10, marginBottom: 12, alignItems: 'center' }}>
+          <div className="r-input" style={{ flex: 1, display: 'flex', alignItems: 'center', gap: 8, padding: '10px 14px' }}>
+            <Icon name="search" size={16} color="var(--text-muted)"/>
+            <input style={{ border: 'none', outline: 'none', background: 'transparent', flex: 1, fontFamily: 'inherit', fontSize: 14 }} placeholder="제목으로 검색"/>
           </div>
+          <div className="r-input" style={{ width: 200, display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '10px 14px', cursor: 'pointer', fontSize: 13 }}>
+            <span style={{ color: 'var(--text-muted)' }}>정렬</span>
+            <span style={{ fontWeight: 600 }}>최근 참여순 ▾</span>
+          </div>
+        </div>
+
+        {/* Filter row 2 — category (single select) */}
+        <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginBottom: 10 }}>
+          {CATEGORY_CHIPS.map((c, i) => (
+            <button key={c.v} style={CHIP(i === 0, 'var(--text)')}>
+              <span>{c.emoji}</span><span>{c.label}</span>
+            </button>
+          ))}
+        </div>
+
+        {/* Filter row 3 — status (single select toggle) */}
+        <div style={{ display: 'flex', gap: 6, marginBottom: 22, alignItems: 'center' }}>
+          <span style={{ fontSize: 11, fontWeight: 700, color: 'var(--text-dim)', letterSpacing: '.08em', textTransform: 'uppercase', marginRight: 4 }}>상태</span>
+          {[
+            { v: 'all', label: '전체' },
+            { v: 'WAITING', label: '대기' },
+            { v: 'ACTIVE', label: '진행중', on: true },
+            { v: 'ENDED', label: '종료' },
+          ].map(s => (
+            <button key={s.v} style={CHIP(s.on, 'var(--coral-500)')}>
+              {s.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Results count */}
+        <div style={{ fontSize: 12, color: 'var(--text-muted)', marginBottom: 14 }}>
+          <span style={{ fontFamily: 'Geist', fontWeight: 700, color: 'var(--text)' }}>{myList.filter(c => c.status === 'ACTIVE').length}개</span>의 진행중인 챌린지
+        </div>
+
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 14 }}>
+          {myList.map((c, i) => <MyChallengeCard key={i} c={c}/>)}
+        </div>
+
+        <Pagination current={1} total={2} perPage={12} totalItems={17}/>
+      </div>
+    </div>
+  );
+};
+
+// ─── Tab 2: Public Challenges ──────────────────────
+const ChallengeBrowsePublicArtboard = () => {
+  const publicList = [
+    { title: '아침 6시 기상 21일', emoji: '🌅', bg: 'linear-gradient(135deg,#FFD166,var(--sunset-500))', category: 'life', status: 'WAITING', startedAt: '2026.05.25', endedAt: '2026.06.14', current: 18, max: 20, description: '하루를 일찍 시작하는 사람들. 6시 전에 일어나서 짧은 메모를 남겨요.' },
+    { title: '주 3회 헬스장', emoji: '💪', bg: 'linear-gradient(135deg,#EF476F,#C9184A)', category: 'fitness', status: 'WAITING', startedAt: '2026.05.27', endedAt: '2026.06.23', current: 6, max: 6, description: '벌크업이든 다이어트든 일단 가야 한다. 인증은 입구 거울샷.' },
+    { title: '저녁 9시 명상', emoji: '🧘', bg: 'linear-gradient(135deg,#9D4EDD,#5D4EDD)', category: 'mind', status: 'WAITING', startedAt: '2026.05.28', endedAt: '2026.06.10', current: 11, max: 30, description: '하루를 차분하게 마무리. 10분 명상 후 짧은 소감 메모.' },
+    { title: '하루 한 권 독서', emoji: '📚', bg: 'linear-gradient(135deg,#118AB2,#06D6A0)', category: 'study', status: 'WAITING', startedAt: '2026.05.29', endedAt: '2026.06.27', current: 4, max: 10, description: '책 한 권을 30일에 걸쳐 읽고 매일 10페이지씩 인증.' },
+    { title: '물 2L 매일', emoji: '💧', bg: 'linear-gradient(135deg,#06D6A0,#06A67D)', category: 'health', status: 'WAITING', startedAt: '2026.06.01', endedAt: '2026.06.30', current: 9, max: 25, description: '컵 사진이면 끝. 가벼운 습관부터 같이 만들어요.' },
+    { title: '21일 그림 그리기', emoji: '🎨', bg: 'linear-gradient(135deg,#F77F00,#D62828)', category: 'hobby', status: 'WAITING', startedAt: '2026.06.03', endedAt: '2026.06.23', current: 7, max: 15, description: '낙서도 좋아요. 매일 한 장씩 손으로 그려서 올려요.' },
+  ];
+
+  return (
+    <div style={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column', background: 'var(--bg)' }}>
+      <AppHeader active="challenges" />
+      <div style={{ flex: 1, overflow: 'auto', padding: '28px 36px' }}>
+        <ChallengeBrowseHeader tab="public" query="tab=public&categories=fitness,mind&sort=startingSoon"/>
+
+        {/* Filter row 1 — search + sort */}
+        <div style={{ display: 'flex', gap: 10, marginBottom: 12, alignItems: 'center' }}>
+          <div className="r-input" style={{ flex: 1, display: 'flex', alignItems: 'center', gap: 8, padding: '10px 14px' }}>
+            <Icon name="search" size={16} color="var(--text-muted)"/>
+            <input style={{ border: 'none', outline: 'none', background: 'transparent', flex: 1, fontFamily: 'inherit', fontSize: 14 }} placeholder="제목으로 검색"/>
+          </div>
+          <div className="r-input" style={{ width: 200, display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '10px 14px', cursor: 'pointer', fontSize: 13 }}>
+            <span style={{ color: 'var(--text-muted)' }}>정렬</span>
+            <span style={{ fontWeight: 600 }}>시작 임박순 ▾</span>
+          </div>
+        </div>
+
+        {/* Multi-select category */}
+        <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginBottom: 14, alignItems: 'center' }}>
+          <span style={{ fontSize: 11, fontWeight: 700, color: 'var(--text-dim)', letterSpacing: '.08em', textTransform: 'uppercase', marginRight: 4 }}>카테고리 (다중)</span>
+          {CATEGORY_CHIPS.filter(c => c.v !== 'all').map(c => {
+            const on = c.v === 'fitness' || c.v === 'mind';
+            return (
+              <button key={c.v} style={CHIP(on, 'var(--coral-500)')}>
+                {on && <Icon name="check" size={11} color="white" strokeWidth={3.5}/>}
+                <span>{c.emoji}</span><span>{c.label}</span>
+              </button>
+            );
+          })}
+          <button style={{ marginLeft: 4, background: 'transparent', border: 'none', cursor: 'pointer', fontSize: 12, fontWeight: 600, color: 'var(--coral-600)' }}>초기화</button>
+        </div>
+
+        {/* Results count */}
+        <div style={{ fontSize: 12, color: 'var(--text-muted)', marginBottom: 14 }}>
+          <span style={{ fontFamily: 'Geist', fontWeight: 700, color: 'var(--text)' }}>142개</span>의 모집중인 챌린지 · WAITING만 표시
+        </div>
+
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 16 }}>
+          {publicList.map((c, i) => <PublicChallengeCard key={i} c={c}/>)}
+        </div>
+
+        <Pagination current={3} total={12} perPage={12} totalItems={142}/>
+      </div>
+    </div>
+  );
+};
+
+// ─── Empty state variant ──────────────────────────
+const ChallengeBrowseEmptyArtboard = () => (
+  <div style={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column', background: 'var(--bg)' }}>
+    <AppHeader active="challenges" />
+    <div style={{ flex: 1, overflow: 'auto', padding: '28px 36px' }}>
+      <ChallengeBrowseHeader tab="mine" query="tab=mine&category=hobby&status=ended&q=피아노"/>
+
+      <div style={{ display: 'flex', gap: 10, marginBottom: 12, alignItems: 'center' }}>
+        <div className="r-input" style={{ flex: 1, display: 'flex', alignItems: 'center', gap: 8, padding: '10px 14px' }}>
+          <Icon name="search" size={16} color="var(--text-muted)"/>
+          <input style={{ border: 'none', outline: 'none', background: 'transparent', flex: 1, fontFamily: 'inherit', fontSize: 14 }} defaultValue="피아노"/>
+        </div>
+        <div className="r-input" style={{ width: 200, display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '10px 14px', cursor: 'pointer', fontSize: 13 }}>
+          <span style={{ color: 'var(--text-muted)' }}>정렬</span>
+          <span style={{ fontWeight: 600 }}>최근 참여순 ▾</span>
+        </div>
+      </div>
+      <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginBottom: 10 }}>
+        {CATEGORY_CHIPS.map((c) => (
+          <button key={c.v} style={CHIP(c.v === 'hobby', 'var(--text)')}>
+            <span>{c.emoji}</span><span>{c.label}</span>
+          </button>
         ))}
+      </div>
+      <div style={{ display: 'flex', gap: 6, marginBottom: 32, alignItems: 'center' }}>
+        <span style={{ fontSize: 11, fontWeight: 700, color: 'var(--text-dim)', letterSpacing: '.08em', textTransform: 'uppercase', marginRight: 4 }}>상태</span>
+        {[
+          { v: 'all', label: '전체' }, { v: 'WAITING', label: '대기' }, { v: 'ACTIVE', label: '진행중' },
+          { v: 'ENDED', label: '종료', on: true },
+        ].map(s => (
+          <button key={s.v} style={CHIP(s.on, 'var(--coral-500)')}>{s.label}</button>
+        ))}
+      </div>
+
+      {/* Empty state */}
+      <div className="r-card" style={{ padding: '64px 32px', textAlign: 'center', background: 'var(--bg)', borderStyle: 'dashed', borderColor: 'var(--border-strong)' }}>
+        <div style={{ fontSize: 56, lineHeight: 1, marginBottom: 16 }}>🌱</div>
+        <div style={{ fontSize: 20, fontWeight: 800, letterSpacing: '-0.02em' }}>아직 결과가 없어요</div>
+        <div style={{ fontSize: 14, color: 'var(--text-muted)', marginTop: 8, maxWidth: 380, margin: '8px auto 0', lineHeight: 1.55 }}>
+          "<b style={{ color: 'var(--text)' }}>피아노</b>" · <b style={{ color: 'var(--text)' }}>취미</b> · <b style={{ color: 'var(--text)' }}>종료</b> 조건에 맞는 챌린지가 없어요.<br/>필터를 조금만 풀어볼까요?
+        </div>
+        <div style={{ display: 'flex', gap: 10, justifyContent: 'center', marginTop: 24 }}>
+          <button className="r-btn r-btn--ghost" style={{ border: '1px solid var(--border-strong)' }}>필터 초기화</button>
+          <button className="r-btn r-btn--primary"><Icon name="plus" size={14}/>새 챌린지 만들기</button>
+        </div>
       </div>
     </div>
   </div>
 );
 
 
-Object.assign(window, { RoutinesArtboard, RoutineDetailArtboard, RoutineCompleteArtboard, RoutineSuccessArtboard, RoutineCreateArtboard, ChallengeDetailArtboard, ChallengeBrowseArtboard });
+Object.assign(window, { RoutinesArtboard, RoutineDetailArtboard, RoutineCompleteArtboard, RoutineSuccessArtboard, RoutineCreateArtboard, ChallengeBrowseArtboard, ChallengeBrowsePublicArtboard, ChallengeBrowseEmptyArtboard });


### PR DESCRIPTION
## ✅ 무엇을 변경했나요?
- 챌린지 목록 화면 개편
  - 카테고리 칩 필터 추가 (`전체 / 운동 / 공부 / 마음챙김 / 생활 / 취미 / 건강`)
  - 상태·카테고리 뱃지 추가
  - 탭 UI 개선

- 챌린지 생성 화면 추가
  - 3섹션 구조 폼 적용
  - 비공개 챌린지 생성 후 초대 링크 모달 추가

- 챌린지 상세 화면 추가
  - Hero 영역
  - 오늘의 루틴 카드
  - 월간 달력
  - 리더보드
  - 피드 영역 포함
  - 상태별 7가지 변형 제공
    - 진행중
    - 대기
    - 루틴 완료
    - 휴식
    - 미완료
    - 종료
    - 방장 메뉴

- 챌린지 수정 화면 추가
  - `WAITING` 상태 전용 수정 모달
  - `ACTIVE` / `ENDED` 상태 수정 불가 화면 추가

## 🎯 왜 변경했나요? (문제 / 배경)
- 챌린지 CRUD 기능(백엔드 #44)에 대응하는 프론트엔드 화면 디자인 기준이 없었다.
- `challenge-service` CRUD API 구현 완료에 따라 생성·목록·상세·수정 화면의 구체적인 디자인 정의가 필요해졌다.

## 🔗 관련 이슈
- Closes #15
- Related: `routinely-backend#44` (챌린지 CRUD API 구현)

## 🧪 테스트 / 검증 방법
- [ ] 로컬 빌드 / 실행 확인
- [ ] 핵심 시나리오 수동 테스트
- [ ] (선택) 단위 / 통합 테스트 추가 또는 수정

### 검증 시나리오
1. `design/v2/Routinely.html`을 브라우저에서 열어 챌린지 생성·목록·상세·수정 아트보드가 정상 렌더링되는지 확인
2. 챌린지 상세 화면의 상태별 변형 7가지가 각각 올바르게 표시되는지 확인
   - 진행중
   - 대기
   - 완료
   - 휴식
   - 미완료
   - 종료
   - 방장 메뉴
3. 챌린지 수정 화면에서 상태별 UI가 정상 구분되는지 확인
   - `WAITING`: 수정 가능
   - `ACTIVE` / `ENDED`: 수정 불가

## 📸 스크린샷 / 로그 (선택)
- UI 변경 사항 스크린샷 첨부 예정

## ✅ 체크리스트
- [ ] 코드가 컴파일 / 빌드됩니다
- [ ] 불필요한 디버그 코드 / 로그를 제거했습니다
- [ ] 에러 케이스를 고려했습니다
- [x] (필요 시) 문서 / 주석을 업데이트했습니다
- [ ] (Back-end) API 변경 시 REST Docs / 스펙을 반영했습니다
- [x] (Front-end) UI / 상태 변경이 의도대로 동작합니다

## 📝 기타 공유사항 (선택)
- 리뷰 참고 사항
  - 헤더 네비게이션·마이페이지 디자인 변경은 이번 PR 범위에서 제외

- 후속 작업(To-do)
  - 모바일 버전 디자인 추가 (#15 또는 별도 이슈)